### PR TITLE
[Fix/#10] 패키지명 변경으로 인한 오류 및 사장님 화면 오류 수정

### DIFF
--- a/app/src/androidTest/java/com/example/naottae/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/naottae/ExampleInstrumentedTest.kt
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.example.naeottae", appContext.packageName)
+        assertEquals("com.example.naottae", appContext.packageName)
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Naeottae"
+        android:theme="@style/Theme.Naottae"
         tools:targetApi="31">
 
         <meta-data
@@ -25,7 +25,7 @@
             android:name=".LoginActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Naeottae">
+            android:theme="@style/Theme.Naottae">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -36,7 +36,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Naeottae">
+            android:theme="@style/Theme.Naottae">
         </activity>
     </application>
 

--- a/app/src/main/java/com/example/naottae/MainActivity.kt
+++ b/app/src/main/java/com/example/naottae/MainActivity.kt
@@ -29,6 +29,20 @@ class MainActivity : AppCompatActivity() {
             .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         val navController = navHostFragment.navController
 
+        val navGraph = navController.navInflater.inflate(R.navigation.nav_graph)
+
+        binding.bottomNavView.menu.clear()
+
+        if (userType == "owner") {
+            binding.bottomNavView.inflateMenu(R.menu.bottom_nav_menu_owner)
+            navGraph.setStartDestination(R.id.shopFragment)
+        } else {
+            binding.bottomNavView.inflateMenu(R.menu.bottom_nav_menu)
+            navGraph.setStartDestination(R.id.homeFragment)
+        }
+
+        navController.graph = navGraph
+
         NavigationUI.setupWithNavController(binding.bottomNavView, navController)
     }
 }

--- a/app/src/main/res/menu/bottom_nav_menu_owner.xml
+++ b/app/src/main/res/menu/bottom_nav_menu_owner.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/ShopFragment"
+        android:id="@+id/shopFragment"
         android:icon="@drawable/ic_shop"
         android:title="매장관리" />
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">naeottae</string>
+    <string name="app_name">naottae</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Base.Theme.Naeottae" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Base.Theme.Naottae" parent="Theme.Material3.DayNight.NoActionBar">
     </style>
 
-    <style name="Theme.Naeottae" parent="Base.Theme.Naeottae" />
+    <style name="Theme.Naottae" parent="Base.Theme.Naottae" />
 </resources>


### PR DESCRIPTION
## ✔️ 작업 내용
- 패키지명 변경 오류 수정
- 사장님 버튼 클릭 후 shopFragment가 아닌 homeFragment가 나타나는 현상 수정
- 사장님 하단바에서 '매장관리' 탭으로 돌아오지 못하는 현상 수정

## 📷 스크린샷
- 오류 수정에 해당하는 내용이므로 생략하겠습니다.

## 💬 참고 사항 <!-- 리뷰어에게 할 말을 작성해주세요. -->
- 패키지명 변경 사항으로 인한 오류의 경우 AndroidStudio의 캐시가 남아있어 발생하는 문제로 보여집니다. 
- 이를 해결하기 위해 File -> Invalidate Caches.. 를 눌러 캐시 초기화를 하면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Navigation now adapts to user type: owners land on Shop by default, others on Home, with corresponding bottom navigation.

- Bug Fixes
  - Corrected app name spelling to “naottae”.
  - Standardized theme naming to ensure consistent styling across the app.
  - Aligned navigation identifiers to prevent mismatches in menus and destinations.

- Chores
  - Updated test configuration to match the correct package naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->