### PR TITLE
[Feature/#22] 사장님 직원 신청 승인 UI 구현

### DIFF
--- a/app/src/main/java/com/example/bisit/ui/shop/ShopNoticesFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopNoticesFragment.kt
@@ -37,25 +37,35 @@ class ShopNoticesFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 여기서 초기화
         adapter = NoticeAdapter(onMoreClick = { notice ->
-            BottomActionSheet(
-                onDelete = {
-                    ConfirmDialog("삭제하시겠어요?", onOk = {
-                        data.removeIf { it.id == notice.id }
-                        adapter.submitList(data.toList())
-                    }).show(parentFragmentManager, "confirm")
-                },
-                onEdit = {
-                    AddNoticeDialog(prefill = notice) { updated ->
-                        val idx = data.indexOfFirst { it.id == updated.id }
-                        if (idx >= 0) {
-                            data[idx] = updated
+            BottomActionSheet().show(parentFragmentManager, "actions")
+
+            // 결과 수신 리스너 설정
+            parentFragmentManager.setFragmentResultListener(
+                BottomActionSheet.REQUEST_KEY,
+                viewLifecycleOwner
+            ) { _, bundle ->
+                when (bundle.getString(BottomActionSheet.RESULT_ACTION)) {
+                    BottomActionSheet.ACTION_DELETE -> {
+                        ConfirmDialog("삭제하시겠어요?", onOk = {
+                            val filtered = data.filterNot { it.id == notice.id }
+                            data.clear()
+                            data.addAll(filtered)
                             adapter.submitList(data.toList())
-                        }
-                    }.show(parentFragmentManager, "edit_notice")
+                        }).show(parentFragmentManager, "confirm")
+                    }
+
+                    BottomActionSheet.ACTION_EDIT -> {
+                        AddNoticeDialog(prefill = notice) { updated ->
+                            val idx = data.indexOfFirst { it.id == updated.id }
+                            if (idx >= 0) {
+                                data[idx] = updated
+                                adapter.submitList(data.toList())
+                            }
+                        }.show(parentFragmentManager, "edit_notice")
+                    }
                 }
-            ).show(parentFragmentManager, "actions")
+            }
         })
 
         binding.rvNotices.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsFragment.kt
@@ -43,26 +43,39 @@ class ShopReviewsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         adapter = ReviewAdapter(onMoreClick = { review ->
-            BottomActionSheet(
-                onDelete = {
-                    ConfirmDialog(
-                        message = "삭제하시겠어요?",
-                        okText = "삭제하기",
-                        onOk = {
-                            data.removeIf { it.id == review.id }
-                            adapter.submitList(data.toList())
-                        }
-                    ).show(parentFragmentManager, "confirm")
-                },
-                onEdit = { /* 리뷰 수정 로직 */ }
-            ).show(parentFragmentManager, "actions")
+            // BottomActionSheet 표시
+            BottomActionSheet().show(parentFragmentManager, "actions")
+
+            // 결과 리스너 등록
+            parentFragmentManager.setFragmentResultListener(
+                BottomActionSheet.REQUEST_KEY,
+                viewLifecycleOwner
+            ) { _, bundle ->
+                when (bundle.getString(BottomActionSheet.RESULT_ACTION)) {
+                    BottomActionSheet.ACTION_DELETE -> {
+                        ConfirmDialog(
+                            message = "삭제하시겠어요?",
+                            okText = "삭제하기",
+                            onOk = {
+                                data.removeAll { it.id == review.id }
+                                sortReviews(isRecentSort)
+                            }
+                        ).show(parentFragmentManager, "confirm")
+                    }
+
+                    BottomActionSheet.ACTION_EDIT -> {
+                        // TODO: 리뷰 수정 로직
+                        // AddReviewDialog(prefill = review) { updated -> ... }
+                    }
+                }
+            }
         })
 
         binding.rvReviews.layoutManager = LinearLayoutManager(requireContext())
         binding.rvReviews.adapter = adapter
         adapter.submitList(data.toList())
 
-        // 정렬 기준 클릭 시 SortOptionDialog 실행
+        // 정렬 옵션 다이얼로그
         binding.tvSortLabel.setOnClickListener {
             SortOptionDialog(isRecentSort) { selectedRecent ->
                 isRecentSort = selectedRecent

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopServicesFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopServicesFragment.kt
@@ -37,25 +37,34 @@ class ShopServicesFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 지역변수 X, 전역 adapter 초기화
         adapter = ServiceAdapter(onMoreClick = { item ->
-            BottomActionSheet(
-                onDelete = {
-                    ConfirmDialog("삭제하시겠어요?", onOk = {
-                        data.removeIf { it.id == item.id }
-                        adapter.submitList(data.toList())
-                    }).show(parentFragmentManager, "confirm")
-                },
-                onEdit = {
-                    AddServiceDialog(prefill = item) { updated ->
-                        val idx = data.indexOfFirst { it.id == updated.id }
-                        if (idx >= 0) {
-                            data[idx] = updated
+            // BottomActionSheet 표시
+            BottomActionSheet().show(parentFragmentManager, "actions")
+
+            // 결과 수신 리스너 등록
+            parentFragmentManager.setFragmentResultListener(
+                BottomActionSheet.REQUEST_KEY,
+                viewLifecycleOwner
+            ) { _, bundle ->
+                when (bundle.getString(BottomActionSheet.RESULT_ACTION)) {
+                    BottomActionSheet.ACTION_DELETE -> {
+                        ConfirmDialog("삭제하시겠어요?", onOk = {
+                            data.removeIf { it.id == item.id }
                             adapter.submitList(data.toList())
-                        }
-                    }.show(parentFragmentManager, "edit_service")
+                        }).show(parentFragmentManager, "confirm")
+                    }
+
+                    BottomActionSheet.ACTION_EDIT -> {
+                        AddServiceDialog(prefill = item) { updated ->
+                            val idx = data.indexOfFirst { it.id == updated.id }
+                            if (idx >= 0) {
+                                data[idx] = updated
+                                adapter.submitList(data.toList())
+                            }
+                        }.show(parentFragmentManager, "edit_service")
+                    }
                 }
-            ).show(parentFragmentManager, "actions")
+            }
         })
 
         binding.rvServices.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/example/bisit/ui/shop/dialog/AddServiceDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/dialog/AddServiceDialog.kt
@@ -27,7 +27,9 @@ class AddServiceDialog(
 
     // 시간/분 선택 BottomSheet 호출
     private fun showDurationPicker() {
-        TimePickerBottomSheet(0, 0) { h, m ->
+        val currentH = b.etHour.text?.toString()?.replace("시간", "")?.toIntOrNull() ?: 0
+        val currentM = b.etMin.text?.toString()?.replace("분", "")?.toIntOrNull() ?: 0
+        TimePickerBottomSheet(currentH, currentM) { h, m ->
             b.etHour.text = "${h}시간"
             b.etMin.text = "${m}분"
         }.show(parentFragmentManager, "durPick")

--- a/app/src/main/java/com/example/bisit/ui/shop/dialog/BottomActionSheet.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/dialog/BottomActionSheet.kt
@@ -10,10 +10,13 @@ import com.example.bisit.R
 import com.example.bisit.databinding.SheetActionsBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class BottomActionSheet(
-    private val onDelete: () -> Unit,
-    private val onEdit: () -> Unit
-) : BottomSheetDialogFragment() {
+class BottomActionSheet : BottomSheetDialogFragment() {
+    companion object {
+        const val REQUEST_KEY = "bottom_action_sheet"
+        const val RESULT_ACTION = "action"
+        const val ACTION_DELETE = "delete"
+        const val ACTION_EDIT = "edit"
+    }
 
     override fun getTheme(): Int = R.style.CustomBottomSheetTheme
 
@@ -30,8 +33,20 @@ class BottomActionSheet(
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        b.btnDelete.setOnClickListener { dismiss(); onDelete() }
-        b.btnEdit.setOnClickListener { dismiss(); onEdit() }
+        b.btnDelete.setOnClickListener {
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply { putString(RESULT_ACTION, ACTION_DELETE) }
+            )
+            dismiss()
+        }
+        b.btnEdit.setOnClickListener {
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply { putString(RESULT_ACTION, ACTION_EDIT) }
+            )
+            dismiss()
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/example/bisit/ui/shop/dialog/ConfirmDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/dialog/ConfirmDialog.kt
@@ -31,10 +31,10 @@ class ConfirmDialog(
         b.btnOk.text = okText
         b.btnCancel.text = cancelText
 
-        b.btnCancel.setOnClickListener { dismissAllowingStateLoss() }
+        b.btnCancel.setOnClickListener { dismiss() }
         b.btnOk.setOnClickListener {
             onOk?.invoke()
-            dismissAllowingStateLoss()
+            dismiss()
         }
     }
 

--- a/app/src/main/java/com/example/bisit/ui/shop/dialog/EditSalesDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/dialog/EditSalesDialog.kt
@@ -31,14 +31,11 @@ class EditSalesDialog(
 
         b.btnSubmit.setOnClickListener {
             val ok = b.etAccount.text?.isNotBlank() == true
-            val dialog = if (ok) {
-                InfoDialog("수정 완료되었습니다.")
-            } else {
-                InfoDialog("인증에 실패하였습니다.")
-            }
-            dialog.show(parentFragmentManager, "info")
             onResult?.invoke(ok)
-            dismissAllowingStateLoss()
+            dismiss()
+
+            val message = if (ok) "수정 완료되었습니다." else "인증에 실패하였습니다."
+            InfoDialog(message).show(parentFragmentManager, "info")
         }
     }
 

--- a/app/src/main/java/com/example/bisit/ui/shop/dialog/InfoDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/dialog/InfoDialog.kt
@@ -31,7 +31,7 @@ class InfoDialog(
 
         b.tvMessage.text = message
         b.btnOnly.text = buttonText
-        b.btnOnly.setOnClickListener { dismissAllowingStateLoss() }
+        b.btnOnly.setOnClickListener { dismiss() }
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffListFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffListFragment.kt
@@ -1,0 +1,37 @@
+package com.example.bisit.ui.staffManage
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.bisit.R
+import com.example.bisit.ui.staffManage.adapter.StaffListAdapter
+
+class StaffListFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_staff_list, container, false)
+
+        val recyclerView = view.findViewById<RecyclerView>(R.id.rvStaffList)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = StaffListAdapter(getDummyStaffs())
+
+        val sortToggle = view.findViewById<ImageView>(R.id.ivSortList)
+        sortToggle.setOnClickListener {
+            Toast.makeText(requireContext(), "정렬 기준 변경", Toast.LENGTH_SHORT).show()
+        }
+
+        return view
+    }
+
+    private fun getDummyStaffs(): List<String> =
+        listOf("직원 A", "직원 B", "직원 C", "직원 D")
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffManagementFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffManagementFragment.kt
@@ -1,0 +1,76 @@
+package com.example.bisit.ui.staffManage
+
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.graphics.toColorInt
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.widget.ViewPager2
+import com.example.bisit.databinding.FragmentStaffManagementBinding
+import com.example.bisit.ui.staffManage.adapter.StaffPagerAdapter
+
+class StaffManagementFragment : Fragment() {
+
+    private var _binding: FragmentStaffManagementBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentStaffManagementBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val pagerAdapter = StaffPagerAdapter(this)
+        binding.viewPagerStaff.adapter = pagerAdapter
+
+        binding.tabRequests.setOnClickListener { binding.viewPagerStaff.currentItem = 0 }
+        binding.tabList.setOnClickListener { binding.viewPagerStaff.currentItem = 1 }
+
+        binding.viewPagerStaff.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                updateTabUI(position)
+            }
+        })
+
+        updateTabUI(0)
+
+        binding.ivBack.setOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
+    }
+
+    private fun updateTabUI(position: Int) {
+        val inactiveColor = "#515965".toColorInt()
+        val activeColor = "#222222".toColorInt()
+        val indicatorColor = "#4076FF".toColorInt()
+
+        listOf(binding.indicatorRequests, binding.indicatorList)
+            .forEach { it.setBackgroundColor(Color.TRANSPARENT) }
+
+        listOf(binding.tvRequests, binding.tvList)
+            .forEach { it.setTextColor(inactiveColor) }
+
+        when (position) {
+            0 -> {
+                binding.indicatorRequests.setBackgroundColor(indicatorColor)
+                binding.tvRequests.setTextColor(activeColor)
+            }
+            1 -> {
+                binding.indicatorList.setBackgroundColor(indicatorColor)
+                binding.tvList.setTextColor(activeColor)
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffRequestsFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffRequestsFragment.kt
@@ -1,0 +1,37 @@
+package com.example.bisit.ui.staffManage
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.bisit.R
+import com.example.bisit.ui.staffManage.adapter.StaffRequestAdapter
+
+class StaffRequestsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_staff_requests, container, false)
+
+        val recyclerView = view.findViewById<RecyclerView>(R.id.rvStaffRequests)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = StaffRequestAdapter(getDummyRequests())
+
+        val sortToggle = view.findViewById<ImageView>(R.id.ivSortRequest)
+        sortToggle.setOnClickListener {
+            Toast.makeText(requireContext(), "정렬 기준 변경", Toast.LENGTH_SHORT).show()
+        }
+
+        return view
+    }
+
+    private fun getDummyRequests(): List<String> =
+        listOf("요청 1", "요청 2", "요청 3", "요청 4")
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffListAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffListAdapter.kt
@@ -1,0 +1,27 @@
+package com.example.bisit.ui.staffManage.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class StaffListAdapter(private val items: List<String>) :
+    RecyclerView.Adapter<StaffListAdapter.StaffViewHolder>() {
+
+    inner class StaffViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val text = itemView.findViewById<TextView>(android.R.id.text1)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StaffViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return StaffViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: StaffViewHolder, position: Int) {
+        holder.text.text = items[position]
+    }
+
+    override fun getItemCount() = items.size
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffPagerAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffPagerAdapter.kt
@@ -1,0 +1,15 @@
+package com.example.bisit.ui.staffManage.adapter
+
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.example.bisit.ui.staffManage.StaffListFragment
+import com.example.bisit.ui.staffManage.StaffRequestsFragment
+
+class StaffPagerAdapter(parent: Fragment) : FragmentStateAdapter(parent) {
+    override fun getItemCount(): Int = 2
+
+    override fun createFragment(position: Int): Fragment = when (position) {
+        0 -> StaffRequestsFragment()
+        else -> StaffListFragment()
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffRequestAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffRequestAdapter.kt
@@ -1,0 +1,27 @@
+package com.example.bisit.ui.staffManage.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class StaffRequestAdapter(private val items: List<String>) :
+    RecyclerView.Adapter<StaffRequestAdapter.RequestViewHolder>() {
+
+    inner class RequestViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val text = itemView.findViewById<TextView>(android.R.id.text1)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RequestViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return RequestViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: RequestViewHolder, position: Int) {
+        holder.text.text = items[position]
+    }
+
+    override fun getItemCount() = items.size
+}

--- a/app/src/main/java/com/example/bisit/ui/todayReserv/dialog/SortOptionDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/todayReserv/dialog/SortOptionDialog.kt
@@ -59,20 +59,20 @@ class SortOptionDialog(
     }
 
     private fun updateUI(recentView: TextView, oldestView: TextView) {
-        val checkRed = ContextCompat.getDrawable(requireContext(), R.drawable.ic_check_blue)
+        val checkBlue = ContextCompat.getDrawable(requireContext(), R.drawable.ic_check_blue)
         val checkGray = ContextCompat.getDrawable(requireContext(), R.drawable.ic_check_gray)
 
         val selectedColor = "#4076FF".toColorInt()
         val unselectedColor = "#6D7583".toColorInt()
 
         if (isRecent) {
-            recentView.setCompoundDrawablesWithIntrinsicBounds(null, null, checkRed, null)
+            recentView.setCompoundDrawablesWithIntrinsicBounds(null, null, checkBlue, null)
             oldestView.setCompoundDrawablesWithIntrinsicBounds(null, null, checkGray, null)
             recentView.setTextColor(selectedColor)
             oldestView.setTextColor(unselectedColor)
         } else {
             recentView.setCompoundDrawablesWithIntrinsicBounds(null, null, checkGray, null)
-            oldestView.setCompoundDrawablesWithIntrinsicBounds(null, null, checkRed, null)
+            oldestView.setCompoundDrawablesWithIntrinsicBounds(null, null, checkBlue, null)
             recentView.setTextColor(unselectedColor)
             oldestView.setTextColor(selectedColor)
         }

--- a/app/src/main/res/drawable/bg_card_white.xml
+++ b/app/src/main/res/drawable/bg_card_white.xml
@@ -1,4 +1,4 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#FEFEFE" />
+    <solid android:color="@color/surface_white" />
     <corners android:radius="16dp" />
 </shape>

--- a/app/src/main/res/drawable/bg_fab_white.xml
+++ b/app/src/main/res/drawable/bg_fab_white.xml
@@ -1,5 +1,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="#FEFEFE" />
+    <solid android:color="@color/surface_white" />
     <corners android:radius="36dp" />
 </shape>

--- a/app/src/main/res/drawable/ic_back.xml
+++ b/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M17,7L10.255,14.227C10.111,14.381 10.111,14.619 10.255,14.773L17,22"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#222222"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ripple_rect.xml
+++ b/app/src/main/res/drawable/ripple_rect.xml
@@ -13,7 +13,7 @@
 
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#FEFEFE"/>
+            <solid android:color="@color/surface_white"/>
             <corners android:radius="12dp"/>
         </shape>
     </item>

--- a/app/src/main/res/layout/dialog_add_notice.xml
+++ b/app/src/main/res/layout/dialog_add_notice.xml
@@ -30,6 +30,7 @@
         android:layout_height="48dp"
         android:hint="제목을 입력해주세요."
         android:padding="12dp"
+        android:inputType="text"
         android:background="@drawable/bg_chip_selector"/>
 
 
@@ -50,6 +51,7 @@
         android:gravity="top"
         android:hint="내용을 입력해주세요."
         android:padding="12dp"
+        android:inputType="textMultiLine|textCapSentences"
         android:background="@drawable/bg_chip_selector"/>
 
 

--- a/app/src/main/res/layout/dialog_add_service.xml
+++ b/app/src/main/res/layout/dialog_add_service.xml
@@ -13,7 +13,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="메뉴 추가하기"
+            android:text="@string/dialog_title_shop_service"
             android:textColor="#222222"
             android:textStyle="bold"
             android:textSize="16sp"/>
@@ -23,7 +23,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            android:text="시술명"
+            android:text="@string/label_service_name"
             android:textColor="#666666"
             android:textSize="14sp"/>
 
@@ -32,7 +32,7 @@
             android:id="@+id/etTitle"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:hint="시술을 입력해주세요."
+            android:hint="@string/hint_service_name"
             android:padding="12dp"
             android:background="@drawable/bg_chip_selector"/>
 
@@ -41,7 +41,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:text="가격"
+            android:text="@string/label_price"
             android:textColor="#666666"
             android:textSize="14sp"/>
 
@@ -50,7 +50,7 @@
             android:id="@+id/etPrice"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:hint="가격을 입력해주세요."
+            android:hint="@string/hint_price"
             android:inputType="number"
             android:padding="12dp"
             android:background="@drawable/bg_chip_selector"/>
@@ -60,7 +60,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:text="소요 시간"
+            android:text="@string/label_duration"
             android:textColor="#666666"
             android:textSize="14sp"/>
 
@@ -97,7 +97,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:text="시술 설명"
+            android:text="@string/label_description"
             android:textColor="#666666"
             android:textSize="14sp"/>
 
@@ -108,7 +108,7 @@
             android:layout_height="wrap_content"
             android:minLines="3"
             android:gravity="top"
-            android:hint="시술 설명을 입력해주세요."
+            android:hint="@string/hint_description"
             android:padding="12dp"
             android:background="@drawable/bg_chip_selector"/>
 
@@ -119,7 +119,7 @@
             android:layout_height="52dp"
             android:layout_marginTop="16dp"
             android:gravity="center"
-            android:text="추가하기"
+            android:text="@string/btn_add"
             android:textColor="#FFFFFF"
             android:textStyle="bold"
             android:background="@drawable/bg_btn_primary_selector"/>

--- a/app/src/main/res/layout/dialog_info.xml
+++ b/app/src/main/res/layout/dialog_info.xml
@@ -25,5 +25,7 @@
         android:text="닫기"
         android:textColor="#FFFFFF"
         android:textStyle="bold"
-        android:background="@drawable/bg_btn_primary_selector"/>
+        android:background="@drawable/bg_btn_primary_selector"
+        android:clickable="true"
+        android:focusable="true"/>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_shop.xml
+++ b/app/src/main/res/layout/fragment_shop.xml
@@ -5,144 +5,100 @@
     android:layout_height="match_parent"
     android:background="#F8F8F8">
 
-    <!-- 헤더 타이틀 -->
-    <TextView
-        android:id="@+id/tvTitle"
-        android:text="매장 관리"
-        android:textColor="#222222"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        android:letterSpacing="0.04"
-        android:layout_marginStart="18dp"
-        android:layout_marginTop="39dp"
-        android:layout_marginBottom="16dp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:paddingHorizontal="18dp">
+
+        <ImageView
+            android:id="@+id/ivBack"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/ic_back"
+            android:contentDescription="뒤로가기" />
+
+        <TextView
+            android:id="@+id/tvTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="직원 관리"
+            android:textColor="#222222"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:layout_toEndOf="@id/ivBack"
+            android:layout_marginStart="6dp"
+            android:layout_centerVertical="true" />
+    </RelativeLayout>
+
 
     <LinearLayout
         android:id="@+id/tabContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:gravity="center"
-        android:layout_marginTop="13dp">
+        android:layout_marginTop="8dp"
+        android:baselineAligned="false">
 
-        <!-- 기본 -->
         <LinearLayout
-            android:id="@+id/tabBasic"
+            android:id="@+id/tabRequests"
             android:orientation="vertical"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:layout_marginEnd="50dp">
+            android:layout_weight="1"
+            android:gravity="center">
 
             <TextView
-                android:id="@+id/tvBasic"
-                android:text="@string/tab_basic"
+                android:id="@+id/tvRequests"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="직원 요청"
                 android:textColor="#6D7583"
                 android:textSize="14sp"
-                android:paddingHorizontal="4dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+                android:singleLine="true"
+                android:gravity="center"
+                android:includeFontPadding="false" />
 
             <View
-                android:id="@+id/indicatorBasic"
-                android:layout_width="match_parent"
+                android:id="@+id/indicatorRequests"
+                android:layout_width="36dp"
                 android:layout_height="3dp"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="6dp"
                 android:background="#4076FF" />
         </LinearLayout>
 
-        <!-- 리뷰 -->
         <LinearLayout
-            android:id="@+id/tabReviews"
+            android:id="@+id/tabList"
             android:orientation="vertical"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:layout_marginEnd="50dp">
+            android:layout_weight="1"
+            android:gravity="center">
 
             <TextView
-                android:id="@+id/tvReviews"
-                android:text="@string/tab_reviews"
+                android:id="@+id/tvList"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="직원 목록"
                 android:textColor="#9AA1AF"
                 android:textSize="14sp"
-                android:paddingHorizontal="4dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+                android:singleLine="true"
+                android:gravity="center"
+                android:includeFontPadding="false" />
 
             <View
-                android:id="@+id/indicatorReviews"
-                android:layout_width="match_parent"
+                android:id="@+id/indicatorList"
+                android:layout_width="36dp"
                 android:layout_height="3dp"
-                android:layout_marginTop="10dp"
-                android:background="@android:color/transparent" />
-        </LinearLayout>
-
-        <!-- 서비스 등록 -->
-        <LinearLayout
-            android:id="@+id/tabServices"
-            android:orientation="vertical"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:layout_marginEnd="50dp">
-
-            <TextView
-                android:id="@+id/tvServices"
-                android:text="@string/tab_services"
-                android:textColor="#9AA1AF"
-                android:textSize="14sp"
-                android:paddingHorizontal="4dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-
-            <View
-                android:id="@+id/indicatorServices"
-                android:layout_width="match_parent"
-                android:layout_height="3dp"
-                android:layout_marginTop="10dp"
-                android:background="@android:color/transparent" />
-        </LinearLayout>
-
-        <!-- 공지사항 -->
-        <LinearLayout
-            android:id="@+id/tabNotices"
-            android:orientation="vertical"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal">
-
-            <TextView
-                android:id="@+id/tvNotices"
-                android:text="@string/tab_notices"
-                android:textColor="#9AA1AF"
-                android:textSize="14sp"
-                android:paddingHorizontal="4dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-
-            <View
-                android:id="@+id/indicatorNotices"
-                android:layout_width="match_parent"
-                android:layout_height="3dp"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="6dp"
                 android:background="@android:color/transparent" />
         </LinearLayout>
     </LinearLayout>
 
-    <!-- 콘텐츠 영역 -->
-    <LinearLayout
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPagerStaff"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:background="#F0F2F5"
-        android:orientation="vertical">
-
-        <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/viewPager"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"/>
-    </LinearLayout>
+        android:layout_weight="1" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_staff_list.xml
+++ b/app/src/main/res/layout/fragment_staff_list.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#F0F2F5">
+
+    <!-- 정렬 기준 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="18dp"
+        android:paddingTop="20dp"
+        android:paddingBottom="12dp">
+
+        <TextView
+            android:id="@+id/tvListLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="직원 목록"
+            android:textColor="#9AA1AF"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/tvSortList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="정렬 기준"
+            android:textColor="#6D7583"
+            android:textSize="14sp" />
+
+        <ImageView
+            android:id="@+id/ivSortList"
+            android:layout_width="10dp"
+            android:layout_height="5dp"
+            android:layout_marginStart="6dp"
+            android:src="@drawable/sort_toggle"
+            android:contentDescription="정렬 변경" />
+    </LinearLayout>
+
+    <!-- 직원 목록 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvStaffList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingHorizontal="18dp"
+        android:clipToPadding="false" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_staff_management.xml
+++ b/app/src/main/res/layout/fragment_staff_management.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#F8F8F8">
+
+    <!-- 헤더 -->
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:paddingHorizontal="18dp"
+        android:gravity="center_vertical"
+        xmlns:tools="http://schemas.android.com/tools"
+        tools:ignore="UseCompoundDrawables"
+        >
+
+        <ImageView
+            android:id="@+id/ivBack"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:src="@drawable/ic_back"
+            android:layout_gravity="center_vertical"
+            android:contentDescription="뒤로가기" />
+
+        <TextView
+            android:id="@+id/tvTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="직원 관리"
+            android:textStyle="bold"
+            android:textColor="#222222"
+            android:textSize="18sp"
+            android:letterSpacing="0.04"
+            android:lineSpacingMultiplier="1.0"
+            android:includeFontPadding="false"
+            android:paddingTop="1dp"
+            android:gravity="center_vertical" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/tabContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="8dp"
+        android:layout_marginHorizontal="20dp"
+        android:baselineAligned="false" >
+
+        <!-- 직원 요청 -->
+        <LinearLayout
+            android:id="@+id/tabRequests"
+            android:orientation="vertical"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/tvRequests"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="직원 요청"
+                android:textColor="#515965"
+                android:textSize="14sp"
+                android:gravity="center"
+                android:includeFontPadding="false" />
+
+            <View
+                android:id="@+id/indicatorRequests"
+                android:layout_width="36dp"
+                android:layout_height="3dp"
+                android:layout_marginTop="8dp"
+                android:background="#4076FF" />
+        </LinearLayout>
+
+        <!-- 직원 목록 -->
+        <LinearLayout
+            android:id="@+id/tabList"
+            android:orientation="vertical"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/tvList"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="직원 목록"
+                android:textColor="#515965"
+                android:textSize="14sp"
+                android:gravity="center"
+                android:includeFontPadding="false" />
+
+            <View
+                android:id="@+id/indicatorList"
+                android:layout_width="36dp"
+                android:layout_height="3dp"
+                android:layout_marginTop="8dp"
+                android:background="@android:color/transparent" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- 콘텐츠 -->
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPagerStaff"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_staff_requests.xml
+++ b/app/src/main/res/layout/fragment_staff_requests.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#F0F2F5">
+
+    <!-- 정렬 기준 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="18dp"
+        android:paddingTop="20dp"
+        android:paddingBottom="12dp">
+
+        <TextView
+            android:id="@+id/tvRequestLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="요청 목록"
+            android:textColor="#9AA1AF"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/tvSortRequest"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="정렬 기준"
+            android:textColor="#6D7583"
+            android:textSize="14sp" />
+
+        <ImageView
+            android:id="@+id/ivSortRequest"
+            android:layout_width="10dp"
+            android:layout_height="5dp"
+            android:layout_marginStart="6dp"
+            android:src="@drawable/sort_toggle"
+            android:contentDescription="정렬 변경" />
+    </LinearLayout>
+
+    <!-- 요청 목록 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvStaffRequests"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingHorizontal="18dp"
+        android:clipToPadding="false" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_today_reserv.xml
+++ b/app/src/main/res/layout/fragment_today_reserv.xml
@@ -28,20 +28,20 @@
 
         <LinearLayout
             android:id="@+id/tabPending"
-            android:orientation="vertical"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="120dp"
             android:gravity="center_horizontal"
-            android:layout_marginEnd="120dp">
+            android:orientation="vertical">
 
             <TextView
                 android:id="@+id/tvPending"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="4dp"
                 android:text="@string/today_tab_pending"
                 android:textColor="#6D7583"
-                android:textSize="14sp"
-                android:paddingHorizontal="4dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+                android:textSize="14sp" />
 
             <View
                 android:id="@+id/indicatorPending"

--- a/app/src/main/res/layout/sheet_actions.xml
+++ b/app/src/main/res/layout/sheet_actions.xml
@@ -14,7 +14,9 @@
         android:padding="14dp"
         android:text="삭제하기"
         android:textColor="#D32F2F"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        android:clickable="true"
+        android:focusable="true" />
 
     <TextView
         android:id="@+id/btnEdit"
@@ -22,7 +24,8 @@
         android:layout_height="wrap_content"
         android:padding="14dp"
         android:text="수정하기"
-        android:textColor="#222222"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        android:clickable="true"
+        android:focusable="true" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/sheet_time_picker.xml
+++ b/app/src/main/res/layout/sheet_time_picker.xml
@@ -42,5 +42,8 @@
         android:text="적용"
         android:textColor="#FFFFFF"
         android:textStyle="bold"
-        android:background="@drawable/bg_btn_primary_selector"/>
+        android:background="@drawable/bg_btn_primary_selector"
+        android:clickable="true"
+        android:focusable="true" />
+
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,5 @@
     <color name="button_red">#FA5453</color>
     <color name="red_FE6B6B">#FE6B6B</color>
     <color name="gray_515965">#515965</color>
+    <color name="surface_white">#FEFEFE</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,4 +81,14 @@
     <string name="label_service">제공 서비스</string>
 
     <string name="underlined_text"><u>수정하기</u></string>
+
+    <!-- add_service -->
+    <string name="dialog_title_shop_service">메뉴 추가하기</string>
+    <string name="label_service_name">시술명</string>
+    <string name="hint_service_name">시술을 입력해주세요.</string>
+    <string name="label_price">가격</string>
+    <string name="hint_price">가격을 입력해주세요.</string>
+    <string name="label_duration">소요 시간</string>
+    <string name="label_description">시술 설명</string>
+    <string name="hint_description">시술 설명을 입력해주세요.</string>
 </resources>


### PR DESCRIPTION
## ✔️ 작업 내용
- **직원 관리(StaffManagementFragment)** 전체 구조 구현  
  - `ViewPager2` + `FragmentStateAdapter`로 **직원 요청 / 직원 목록** 탭 전환 기능 완성  
  - 각 탭을 독립 `Fragment`로 구성하여 코드 가독성과 유지보수성 향상  
  - 탭 클릭 및 스와이프 모두 지원하도록 `registerOnPageChangeCallback` 연결  
- **탭 UI 세부 조정**  
  - 두 탭이 화면 너비를 균등하게 차지하도록 `layout_weight` 적용  
  - indicator 길이 **36dp 고정**, 텍스트는 중앙 정렬 유지  
  - 탭 전환 시 텍스트 색상 `#515965 → #222222`, indicator 색상 `transparent → #4076FF` 변경  
- **헤더(뒤로가기 + 제목) 정렬 개선**  
  - `RelativeLayout` → `LinearLayout` 변경으로 정확한 수평 정렬 구현  
  - 아이콘 크기 **28dp**, 텍스트와의 간격 **8dp**로 시각적으로 완벽한 평행 정렬  
- **Lint 경고(`UseCompoundDrawables`) 처리**  
  - 복합 drawable 대체가 불가한 구조로 판단하여 `tools:ignore="UseCompoundDrawables"` 적용  

## 💡 개선 및 고려한 점
- 탭 영역을 `LinearLayout + weight` 기반으로 균등 분배 → 반응형 대응  
- Fragment 구조를 `ShopFragment`와 통일하여 추후 확장 용이  
- 불필요한 Lint 권고는 배제하고, 실질적 **UI 정렬 정확도**에 집중  
- 전체 뷰 계층을 단순화해 **명확한 역할 분리** 유지  

## 📷 스크린샷
- 직원 관리 헤더 및 탭 정렬 화면  
- 직원 요청 / 직원 목록 탭 전환 시 indicator 및 색상 변화  

<img width="204" height="365" alt="image" src="https://github.com/user-attachments/assets/706b006a-634a-4a27-8ff6-c0021780be9f" />

## 💬 참고 사항
- 추후 `RecyclerView` 및 서버 API 연동 시  
  `StaffRequestsFragment` / `StaffListFragment` 내 데이터 바인딩 예정  
- 탭 전환 시 상태 유지 기능  
  (`FragmentStateAdapter.BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT`) 적용 고려  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staff management interface with separate tabs for requests and staff list
  * Time picker now initializes with current duration values when editing service details

* **Bug Fixes**
  * Improved dialog lifecycle handling for enhanced stability

* **UI/UX Improvements**
  * Added back navigation button for easier navigation
  * Enhanced accessibility support for interactive dialog elements
  * Implemented resource-based colors for consistent theming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->