### PR TITLE
[Feature/#50] 로그인 API 연결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Bisit"
-        tools:targetApi="31">
+        tools:targetApi="31"
+
+        android:usesCleartextTraffic="true">
 
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"

--- a/app/src/main/java/com/example/bisit/data/api/AuthApiService.kt
+++ b/app/src/main/java/com/example/bisit/data/api/AuthApiService.kt
@@ -1,0 +1,12 @@
+package com.example.bisit.data.api
+
+import com.example.bisit.data.model.auth.LoginRequest
+import com.example.bisit.data.model.auth.LoginResponse
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApiService {
+    @POST("/api/auth/login")
+    fun login(@Body request: LoginRequest): Call<LoginResponse>
+}

--- a/app/src/main/java/com/example/bisit/data/api/AuthInterceptor.kt
+++ b/app/src/main/java/com/example/bisit/data/api/AuthInterceptor.kt
@@ -1,0 +1,34 @@
+package com.example.bisit.data.api
+
+import android.content.Context
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthInterceptor(private val context: Context) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val urlPath = originalRequest.url.encodedPath
+
+        // 토큰이 필요 없는 API 경로 목록 (로그인, 회원가입 등)
+        val noAuthPaths = listOf(
+            "/api/auth/login",
+            "/api/auth/sign-up"
+        )
+
+        // 해당 경로가 포함되어 있으면 토큰 없이 진행
+        if (noAuthPaths.any { urlPath.contains(it) }) {
+            return chain.proceed(originalRequest)
+        }
+
+        val token = TokenManager.getAccessToken(context)
+
+        return if (token != null) {
+            val newRequest = originalRequest.newBuilder()
+                .addHeader("Authorization", "Bearer $token")
+                .build()
+            chain.proceed(newRequest)
+        } else {
+            chain.proceed(originalRequest)
+        }
+    }
+}

--- a/app/src/main/java/com/example/bisit/data/api/RetrofitClient.kt
+++ b/app/src/main/java/com/example/bisit/data/api/RetrofitClient.kt
@@ -1,13 +1,14 @@
 package com.example.bisit.data.api
 
+import android.content.Context
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import com.example.bisit.BuildConfig
+import java.util.concurrent.TimeUnit
 
 object RetrofitClient {
-    private const val BASE_URL = "https://naveropenapi.apigw.ntruss.com/"
-
+    private const val NAVER_BASE_URL = "https://naveropenapi.apigw.ntruss.com/"
     private const val NCP_ACCESS_KEY_ID = "ncp_iam_BPAMKR3PLgKeBYxJmUID"
     private const val NCP_SECRET_KEY = "ncp_iam_BPKMKRX3UqkCGZPw1EAquRBDKK6hscFwiz"
 
@@ -23,20 +24,49 @@ object RetrofitClient {
 
     val geocodingApi: NaverGeocodingApiService by lazy {
         Retrofit.Builder()
-            .baseUrl(BASE_URL)
+            .baseUrl(NAVER_BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .client(naverClient)
             .build()
             .create(NaverGeocodingApiService::class.java)
     }
 
+    //local.properties에서 BASE_SERVER_URL = http:// ~~ 이렇게 추가하시면 됩니다
     private val BASE_SERVER_URL = BuildConfig.BASE_SERVER_URL
+    private var serverRetrofit: Retrofit? = null
 
-    val todayReservationApi: TodayReservationApiService by lazy {
-        Retrofit.Builder()
-            .baseUrl(BASE_SERVER_URL)
-            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-            .create(TodayReservationApiService::class.java)
+    private fun getServerRetrofit(context: Context): Retrofit {
+        if (serverRetrofit == null) {
+            val client = OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .addInterceptor(AuthInterceptor(context))
+                .build()
+
+            serverRetrofit = Retrofit.Builder()
+                .baseUrl(BASE_SERVER_URL)
+                .addConverterFactory(GsonConverterFactory.create())
+                .client(client)
+                .build()
+        }
+        return serverRetrofit!!
     }
+
+    fun getAuthApi(context: Context): AuthApiService {
+        return getServerRetrofit(context).create(AuthApiService::class.java)
+    }
+
+    fun getTodayReservationApi(context: Context): TodayReservationApiService {
+        return getServerRetrofit(context).create(TodayReservationApiService::class.java)
+    }
+
+    // 토큰이 안넘어가는 방식이기 때문에 위에 getTodatReservationApi로 대체하는게 좋을 것으로 보입니다!
+//    val todayReservationApi: TodayReservationApiService by lazy {
+//        Retrofit.Builder()
+//            .baseUrl(BASE_SERVER_URL)
+//            .addConverterFactory(GsonConverterFactory.create())
+//            .build()
+//            .create(TodayReservationApiService::class.java)
+//    }
 }

--- a/app/src/main/java/com/example/bisit/data/api/TokenManager.kt
+++ b/app/src/main/java/com/example/bisit/data/api/TokenManager.kt
@@ -1,0 +1,33 @@
+package com.example.bisit.data.api
+
+import android.content.Context
+
+object TokenManager {
+    private const val PREF_NAME = "auth_prefs"
+    private const val KEY_ACCESS_TOKEN = "accessToken"
+    private const val KEY_REFRESH_TOKEN = "refreshToken"
+    private const val KEY_USER_ROLE = "userRole"
+
+    fun saveTokens(context: Context, accessToken: String, refreshToken: String) {
+        val pref = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        pref.edit()
+            .putString(KEY_ACCESS_TOKEN, accessToken)
+            .putString(KEY_REFRESH_TOKEN, refreshToken)
+            .apply()
+    }
+
+    fun getAccessToken(context: Context): String? {
+        val pref = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        return pref.getString(KEY_ACCESS_TOKEN, null)
+    }
+
+    fun getRefreshToken(context: Context): String? {
+        val pref = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        return pref.getString(KEY_REFRESH_TOKEN, null)
+    }
+
+    fun clearTokens(context: Context) {
+        val pref = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        pref.edit().clear().apply()
+    }
+}

--- a/app/src/main/java/com/example/bisit/data/model/auth/LoginRequest.kt
+++ b/app/src/main/java/com/example/bisit/data/model/auth/LoginRequest.kt
@@ -1,0 +1,6 @@
+package com.example.bisit.data.model.auth
+
+data class LoginRequest(
+    val loginId: String,
+    val password: String
+)

--- a/app/src/main/java/com/example/bisit/data/model/auth/LoginResponse.kt
+++ b/app/src/main/java/com/example/bisit/data/model/auth/LoginResponse.kt
@@ -1,0 +1,13 @@
+package com.example.bisit.data.model.auth
+
+data class LoginResponse(
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: TokenData?
+)
+
+data class TokenData(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/app/src/main/java/com/example/bisit/ui/login/LoginCredentialsFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/login/LoginCredentialsFragment.kt
@@ -1,13 +1,17 @@
 package com.example.bisit.ui.login
 
+import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
-import android.text.TextWatcher // TextWatcher 임포트
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.example.bisit.MainActivity // 메인 액티비티 임포트
 import com.example.bisit.R
 import com.example.bisit.databinding.FragmentLoginCredentialsBinding
 
@@ -15,6 +19,7 @@ class LoginCredentialsFragment : Fragment() {
 
     private var _binding: FragmentLoginCredentialsBinding? = null
     private val binding get() = _binding!!
+    private val viewModel: LoginViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -28,12 +33,17 @@ class LoginCredentialsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupClickListeners()
-        setupTextWatchers() // 텍스트 변경 리스너 설정 추가
+        setupTextWatchers()
+        observeViewModel()
     }
 
     private fun setupClickListeners() {
         binding.btnLogin.setOnClickListener {
-            // TODO: 로그인 로직 구현 (ViewModel 호출)
+            val id = binding.etId.text.toString()
+            val pw = binding.etPassword.text.toString()
+
+            // ViewModel에 로그인 요청
+            viewModel.login(requireContext(), id, pw)
         }
 
         binding.tvFindId.setOnClickListener {
@@ -41,39 +51,41 @@ class LoginCredentialsFragment : Fragment() {
         }
 
         binding.tvFindPassword.setOnClickListener {
-            // 비밀번호 찾기 Fragment로 이동
             findNavController().navigate(R.id.action_loginCredentialsFragment_to_findPasswordFragment)
         }
     }
 
-    // 텍스트 변경 리스너 설정 메서드
-    private fun setupTextWatchers() {
-        // 아이디와 비밀번호 EditText에 동일한 TextWatcher를 적용
-        val textWatcher = object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                // 텍스트가 변경될 때마다 버튼 활성화 상태를 업데이트
-                updateLoginButtonState()
+    private fun observeViewModel() {
+        viewModel.loginResult.observe(viewLifecycleOwner) { isSuccess ->
+            if (isSuccess) {
+                Toast.makeText(context, "로그인 성공!", Toast.LENGTH_SHORT).show()
+                val intent = Intent(requireContext(), MainActivity::class.java)
+                startActivity(intent)
+                requireActivity().finish()
             }
-
-            override fun afterTextChanged(s: Editable?) {}
         }
 
+        viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+    private fun setupTextWatchers() {
+        val textWatcher = object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                updateLoginButtonState()
+            }
+            override fun afterTextChanged(s: Editable?) {}
+        }
         binding.etId.addTextChangedListener(textWatcher)
         binding.etPassword.addTextChangedListener(textWatcher)
     }
 
-    // 로그인 버튼 활성화 상태 업데이트 메서드
     private fun updateLoginButtonState() {
-        // 아이디와 비밀번호 필드가 모두 비어있지 않은지 확인
         val isIdValid = binding.etId.text.isNullOrBlank().not()
         val isPasswordValid = binding.etPassword.text.isNullOrBlank().not()
-
-        // 두 조건이 모두 충족되면 버튼을 활성화
         binding.btnLogin.isEnabled = isIdValid && isPasswordValid
     }
-
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/java/com/example/bisit/ui/login/LoginCredentialsFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/login/LoginCredentialsFragment.kt
@@ -59,7 +59,19 @@ class LoginCredentialsFragment : Fragment() {
         viewModel.loginResult.observe(viewLifecycleOwner) { isSuccess ->
             if (isSuccess) {
                 Toast.makeText(context, "로그인 성공!", Toast.LENGTH_SHORT).show()
+
                 val intent = Intent(requireContext(), MainActivity::class.java)
+
+                // 임시로 id에 따른 분기처리
+                val inputId = binding.etId.text.toString()
+                val userType = when (inputId) {
+                    "rlatkwkd" -> "owner"
+                    "rlathssla" -> "customer"
+                    else -> "customer"
+                }
+
+                intent.putExtra("USER_TYPE", userType)
+
                 startActivity(intent)
                 requireActivity().finish()
             }
@@ -69,6 +81,7 @@ class LoginCredentialsFragment : Fragment() {
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
     }
+
     private fun setupTextWatchers() {
         val textWatcher = object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}

--- a/app/src/main/java/com/example/bisit/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/bisit/ui/login/LoginViewModel.kt
@@ -1,0 +1,55 @@
+package com.example.bisit.ui.login
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.bisit.data.api.RetrofitClient
+import com.example.bisit.data.api.TokenManager
+import com.example.bisit.data.model.auth.LoginRequest
+import com.example.bisit.data.model.auth.LoginResponse
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class LoginViewModel : ViewModel() {
+
+    private val _loginResult = MutableLiveData<Boolean>()
+    val loginResult: LiveData<Boolean> get() = _loginResult
+
+    private val _errorMessage = MutableLiveData<String>()
+    val errorMessage: LiveData<String> get() = _errorMessage
+
+    fun login(context: Context, id: String, pw: String) {
+        val request = LoginRequest(id, pw)
+
+        RetrofitClient.getAuthApi(context).login(request).enqueue(object : Callback<LoginResponse> {
+            override fun onResponse(call: Call<LoginResponse>, response: Response<LoginResponse>) {
+                if (response.isSuccessful && response.body() != null) {
+                    val result = response.body()!!
+
+                    // success가 true이고 데이터가 존재할 때만 로그인 성공 처리
+                    if (result.success && result.data != null) {
+                        TokenManager.saveTokens(context, result.data.accessToken, result.data.refreshToken)
+                        _loginResult.value = true
+                    } else {
+                        // 서버에서 success: false로 보낸 경우 (비번 불일치 등)
+                        _errorMessage.value = result.message ?: "로그인에 실패했습니다."
+                        _loginResult.value = false
+                    }
+                } else {
+                    // HTTP 상태 코드가 200번대가 아닌 경우
+                    _errorMessage.value = "서버 오류: ${response.code()}"
+                    _loginResult.value = false
+                }
+            }
+
+            override fun onFailure(call: Call<LoginResponse>, t: Throwable) {
+                Log.e("LoginViewModel", "Network Error", t)
+                _errorMessage.value = "네트워크 연결을 확인해주세요."
+                _loginResult.value = false
+            }
+        })
+    }
+}


### PR DESCRIPTION
## ✔️ 작업 내용
- 로그인 api 연결
- 토큰 관리 설정
- id에 따른 사장님, 손님 구분

## 📷 스크린샷
- 김사장 id로 로그인
<img width="200" height="2400" alt="image" src="https://github.com/user-attachments/assets/5d4579db-8c40-4de0-b7bc-08bb5d0f1625" />


- 김손님 id로 로그인
<img width="200" height="2400" alt="image" src="https://github.com/user-attachments/assets/ffac3683-cccf-402d-b663-3f8eecd66b97" />


## 💬 참고 사항 <!-- 리뷰어에게 할 말을 작성해주세요. -->
- 현재 로그인 api에 사용자가 사장님인지 손님인지 구분할 수 있는 로직이 없기 때문에 id에 따라 구분하도록 하드코딩한 상태입니다. 
   해당 api가 수정되는대로 해당 로직 수정하도록 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그인 기능 구현 - 사용자 ID와 비밀번호로 인증 가능
  * 인증 토큰 자동 관리 - 로그인 후 접근 권한 자동 저장 및 관리
  * API 요청 자동 인증 - 저장된 권한으로 API 호출 시 자동 인증 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->