### PR TITLE
[Feature/#63] 사장님 직원 신청/승인/삭제 API 연동

### DIFF
--- a/app/src/main/java/com/example/bisit/data/api/RetrofitClient.kt
+++ b/app/src/main/java/com/example/bisit/data/api/RetrofitClient.kt
@@ -102,5 +102,6 @@ object RetrofitClient {
     fun getCustomerShopApi(context: Context) =
         getServerRetrofit(context).create(CustomerShopApiService::class.java)
 
-
+    fun getStaffManageApi(context: Context) =
+        getServerRetrofit(context).create(StaffManageApiService::class.java)
 }

--- a/app/src/main/java/com/example/bisit/data/api/StaffManageApiService.kt
+++ b/app/src/main/java/com/example/bisit/data/api/StaffManageApiService.kt
@@ -1,0 +1,41 @@
+package com.example.bisit.data.api
+
+import com.example.bisit.data.model.staffManage.*
+import retrofit2.http.*
+
+interface StaffManageApiService {
+
+    // 사장님 → 직원 직접 추가
+    @POST("/api/shops/{shopId}/staff/add")
+    suspend fun addStaff(
+        @Path("shopId") shopId: Long,
+        @Body request: AddStaffRequest
+    ): ApiResponse<StaffResponse>
+
+    // 승인된 직원 삭제
+    @DELETE("/api/shops/{shopId}/staff/{staffId}")
+    suspend fun deleteStaff(
+        @Path("shopId") shopId: Long,
+        @Path("staffId") staffId: Long
+    ): ApiResponse<String>
+
+    // 직원 신청 승인 / 거절
+    @PATCH("/api/shops/{shopId}/staff/{staffId}")
+    suspend fun updateStaffStatus(
+        @Path("shopId") shopId: Long,
+        @Path("staffId") staffId: Long,
+        @Query("status") status: StaffStatus
+    ): ApiResponse<StaffResponse>
+
+    // 직원 신청 목록 조회 (직원 요청 탭)
+    @GET("/api/shops/{shopId}/staff/pending")
+    suspend fun getPendingStaffs(
+        @Path("shopId") shopId: Long
+    ): ApiResponse<List<PendingStaffItem>>
+
+    // 승인된 직원 목록 조회 (직원 목록 탭)
+    @GET("/api/shops/{shopId}/staff/approved")
+    suspend fun getApprovedStaffs(
+        @Path("shopId") shopId: Long
+    ): ApiResponse<List<ApprovedStaffItem>>
+}

--- a/app/src/main/java/com/example/bisit/data/model/staffManage/StaffManageModels.kt
+++ b/app/src/main/java/com/example/bisit/data/model/staffManage/StaffManageModels.kt
@@ -1,0 +1,40 @@
+package com.example.bisit.data.model.staffManage
+
+enum class StaffStatus {
+    PENDING, APPROVED, REJECTED, DELETED
+}
+
+data class AddStaffRequest(
+    val name: String,
+    val email: String,
+    val phone: String
+)
+
+// 직원-가게 관계 응답
+data class StaffResponse(
+    val id: Long,
+    val memberId: Long,
+    val shopId: Long,
+    val status: StaffStatus
+)
+
+// 직원 신청 목록 아이템
+data class PendingStaffItem(
+    val staffId: Long,
+    val name: String,
+    val phone: String
+)
+
+// 승인된 직원 목록 아이템
+data class ApprovedStaffItem(
+    val staffId: Long,
+    val name: String
+)
+
+// 공통 API 응답
+data class ApiResponse<T>(
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: T
+)

--- a/app/src/main/java/com/example/bisit/data/repository/staffManage/StaffManageRepository.kt
+++ b/app/src/main/java/com/example/bisit/data/repository/staffManage/StaffManageRepository.kt
@@ -1,0 +1,58 @@
+package com.example.bisit.data.repository.staffManage
+
+import com.example.bisit.data.api.StaffManageApiService
+import com.example.bisit.data.model.staffManage.*
+
+class StaffManageRepository(
+    private val api: StaffManageApiService
+) {
+
+    suspend fun addStaff(
+        shopId: Long,
+        name: String,
+        email: String,
+        phone: String
+    ): StaffResponse {
+        return api.addStaff(
+            shopId,
+            AddStaffRequest(name, email, phone)
+        ).data
+    }
+
+    suspend fun deleteStaff(
+        shopId: Long,
+        staffId: Long
+    ): String {
+        return api.deleteStaff(shopId, staffId).data
+    }
+
+    suspend fun approveStaff(
+        shopId: Long,
+        staffId: Long
+    ): StaffResponse {
+        return api.updateStaffStatus(
+            shopId,
+            staffId,
+            StaffStatus.APPROVED
+        ).data
+    }
+
+    suspend fun rejectStaff(
+        shopId: Long,
+        staffId: Long
+    ): StaffResponse {
+        return api.updateStaffStatus(
+            shopId,
+            staffId,
+            StaffStatus.REJECTED
+        ).data
+    }
+
+    suspend fun getPendingStaffs(shopId: Long): List<PendingStaffItem> {
+        return api.getPendingStaffs(shopId).data
+    }
+
+    suspend fun getApprovedStaffs(shopId: Long): List<ApprovedStaffItem> {
+        return api.getApprovedStaffs(shopId).data
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffListFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffListFragment.kt
@@ -7,22 +7,58 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.bisit.R
+import com.example.bisit.data.api.RetrofitClient
+import com.example.bisit.data.repository.staffManage.StaffManageRepository
 import com.example.bisit.ui.staffManage.adapter.StaffListAdapter
+import com.example.bisit.ui.staffManage.modal.DeleteCompleteDialog
+import com.example.bisit.ui.staffManage.modal.DeleteStaffDialog
+import kotlinx.coroutines.launch
 
 class StaffListFragment : Fragment() {
 
+    // StaffManage 전체에서 공유하는 ViewModel
+    private val viewModel: StaffManageViewModel by activityViewModels {
+        StaffManageViewModelFactory(
+            StaffManageRepository(
+                RetrofitClient.getStaffManageApi(requireContext())
+            )
+        )
+    }
+
+    private lateinit var adapter: StaffListAdapter
+
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
+
         val view = inflater.inflate(R.layout.fragment_staff_list, container, false)
+
+        adapter = StaffListAdapter(
+            onDeleteClick = { staff ->
+                showDeleteDialog(staff.staffId)
+            }
+        )
 
         val recyclerView = view.findViewById<RecyclerView>(R.id.rvStaffList)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        recyclerView.adapter = StaffListAdapter(getDummyStaffs())
+        recyclerView.adapter = adapter
+
+        // 승인된 직원 목록
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.approvedStaffs.collect { list ->
+                adapter.submitList(list)
+            }
+        }
+
+        // 최초 로드
+        viewModel.loadApprovedStaffs(getShopId())
 
         val sortToggle = view.findViewById<ImageView>(R.id.ivSortList)
         sortToggle.setOnClickListener {
@@ -32,6 +68,26 @@ class StaffListFragment : Fragment() {
         return view
     }
 
-    private fun getDummyStaffs(): List<String> =
-        listOf("직원 A", "직원 B", "직원 C", "직원 D")
+    private fun showDeleteDialog(staffId: Long) {
+        DeleteStaffDialog(
+            onConfirm = {
+                // 직원 삭제 (리스트 즉시 반영)
+                viewModel.deleteStaff(getShopId(), staffId)
+
+                // ️기존 삭제 확인 모달 닫기
+                (parentFragmentManager.findFragmentByTag("delete_staff")
+                        as? DeleteStaffDialog)?.dismiss()
+
+                // 삭제 완료 모달 표시
+                DeleteCompleteDialog().show(
+                    parentFragmentManager,
+                    "delete_complete"
+                )
+            }
+        ).show(parentFragmentManager, "delete_staff")
+    }
+
+    private fun getShopId(): Long {
+        return requireArguments().getLong("shopId")
+    }
 }

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffManageViewModel.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffManageViewModel.kt
@@ -1,0 +1,65 @@
+package com.example.bisit.ui.staffManage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.bisit.data.model.staffManage.ApprovedStaffItem
+import com.example.bisit.data.model.staffManage.PendingStaffItem
+import com.example.bisit.data.repository.staffManage.StaffManageRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class StaffManageViewModel(
+    private val repository: StaffManageRepository
+) : ViewModel() {
+
+    // 승인 대기 직원 요청
+    private val _pendingStaffs =
+        MutableStateFlow<List<PendingStaffItem>>(emptyList())
+    val pendingStaffs: StateFlow<List<PendingStaffItem>> = _pendingStaffs
+
+    // 승인된 직원 목록
+    private val _approvedStaffs = MutableStateFlow<List<ApprovedStaffItem>>(emptyList())
+    val approvedStaffs: StateFlow<List<ApprovedStaffItem>> = _approvedStaffs
+
+
+    fun loadPendingStaffs(shopId: Long) {
+        viewModelScope.launch {
+            runCatching {
+                repository.getPendingStaffs(shopId)
+            }.onSuccess { list ->
+                _pendingStaffs.value = list
+            }
+        }
+    }
+
+    fun approveStaff(shopId: Long, staffId: Long) {
+        viewModelScope.launch {
+            repository.approveStaff(shopId, staffId)
+            loadPendingStaffs(shopId) // 승인 후 목록 갱신
+        }
+    }
+
+    fun rejectStaff(shopId: Long, staffId: Long) {
+        viewModelScope.launch {
+            repository.rejectStaff(shopId, staffId)
+            loadPendingStaffs(shopId) // 거절 후 목록 갱신
+        }
+    }
+
+    fun loadApprovedStaffs(shopId: Long) {
+        viewModelScope.launch {
+            val list = repository.getApprovedStaffs(shopId)
+            _approvedStaffs.value = list // 승인된 직원 목록
+        }
+    }
+
+    fun deleteStaff(shopId: Long, staffId: Long) {
+        viewModelScope.launch {
+            repository.deleteStaff(shopId, staffId)
+            // 현재 리스트에서 제거
+            _approvedStaffs.value =
+                _approvedStaffs.value.filterNot { it.staffId == staffId }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffRequestsFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffRequestsFragment.kt
@@ -7,22 +7,64 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.bisit.R
+import com.example.bisit.data.api.RetrofitClient
+import com.example.bisit.data.repository.staffManage.StaffManageRepository
 import com.example.bisit.ui.staffManage.adapter.StaffRequestAdapter
+import com.example.bisit.ui.staffManage.modal.StaffRequestResultDialog
+import kotlinx.coroutines.launch
 
 class StaffRequestsFragment : Fragment() {
 
+    private lateinit var viewModel: StaffManageViewModel
+    private lateinit var adapter: StaffRequestAdapter
+
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
+
         val view = inflater.inflate(R.layout.fragment_staff_requests, container, false)
 
+        // API / Repository / ViewModel
+        val api = RetrofitClient.getStaffManageApi(requireContext())
+        val repository = StaffManageRepository(api)
+
+        viewModel = ViewModelProvider(
+            this,
+            StaffManageViewModelFactory(repository)
+        )[StaffManageViewModel::class.java]
+
+        // RecyclerView
         val recyclerView = view.findViewById<RecyclerView>(R.id.rvStaffRequests)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        recyclerView.adapter = StaffRequestAdapter(getDummyRequests())
+
+        adapter = StaffRequestAdapter(
+            onApprove = { staffId ->
+                viewModel.approveStaff(getShopId(), staffId)
+                showResultDialog("직원 요청이 승인되었습니다.")
+            },
+            onReject = { staffId ->
+                viewModel.rejectStaff(getShopId(), staffId)
+                showResultDialog("직원 요청이 거절되었습니다.")
+            }
+        )
+        recyclerView.adapter = adapter
+
+        // 직원 신청 목록 최초 로드
+        viewModel.loadPendingStaffs(getShopId())
+
+        // 목록 관찰
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.pendingStaffs.collect { list ->
+                adapter.submitList(list)
+            }
+        }
 
         val sortToggle = view.findViewById<ImageView>(R.id.ivSortRequest)
         sortToggle.setOnClickListener {
@@ -32,6 +74,12 @@ class StaffRequestsFragment : Fragment() {
         return view
     }
 
-    private fun getDummyRequests(): List<String> =
-        listOf("요청 1", "요청 2", "요청 3", "요청 4")
+    private fun showResultDialog(message: String) {
+        StaffRequestResultDialog(message)
+            .show(parentFragmentManager, "staff_request_result")
+    }
+
+    private fun getShopId(): Long {
+        return requireArguments().getLong("shopId")
+    }
 }

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffViewModelFactory.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffViewModelFactory.kt
@@ -1,0 +1,18 @@
+package com.example.bisit.ui.staffManage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.bisit.data.repository.staffManage.StaffManageRepository
+
+class StaffManageViewModelFactory(
+    private val repository: StaffManageRepository
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(StaffManageViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return StaffManageViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffListAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffListAdapter.kt
@@ -4,24 +4,34 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.example.bisit.R
+import com.example.bisit.data.model.staffManage.ApprovedStaffItem
 
-class StaffListAdapter(private val items: List<String>) :
-    RecyclerView.Adapter<StaffListAdapter.StaffViewHolder>() {
+class StaffListAdapter(
+    private val onDeleteClick: (ApprovedStaffItem) -> Unit
+) : ListAdapter<ApprovedStaffItem, StaffListAdapter.StaffViewHolder>(
+    StaffListDiffCallback
+) {
 
     inner class StaffViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val text = itemView.findViewById<TextView>(android.R.id.text1)
+        val tvName: TextView = itemView.findViewById(R.id.tvStaffName)
+        val btnDelete: TextView = itemView.findViewById(R.id.btnStaffDelete)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StaffViewHolder {
         val view = LayoutInflater.from(parent.context)
-            .inflate(android.R.layout.simple_list_item_1, parent, false)
+            .inflate(R.layout.item_staff_list, parent, false)
         return StaffViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: StaffViewHolder, position: Int) {
-        holder.text.text = items[position]
-    }
+        val item = getItem(position)
 
-    override fun getItemCount() = items.size
+        holder.tvName.text = item.name
+        holder.btnDelete.setOnClickListener {
+            onDeleteClick(item)
+        }
+    }
 }

--- a/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffListDiffCallback.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffListDiffCallback.kt
@@ -1,0 +1,23 @@
+package com.example.bisit.ui.staffManage.adapter
+
+import androidx.recyclerview.widget.DiffUtil
+import com.example.bisit.data.model.staffManage.ApprovedStaffItem
+
+object StaffListDiffCallback : DiffUtil.ItemCallback<ApprovedStaffItem>() {
+
+    override fun areItemsTheSame(
+        oldItem: ApprovedStaffItem,
+        newItem: ApprovedStaffItem
+    ): Boolean {
+        // 같은 직원인지 판단 (고유 ID)
+        return oldItem.staffId == newItem.staffId
+    }
+
+    override fun areContentsTheSame(
+        oldItem: ApprovedStaffItem,
+        newItem: ApprovedStaffItem
+    ): Boolean {
+        // 내용 변경 여부
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffRequestAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffRequestAdapter.kt
@@ -4,24 +4,46 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import com.google.android.material.button.MaterialButton
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.example.bisit.R
+import com.example.bisit.data.model.staffManage.PendingStaffItem
+import com.example.bisit.ui.staffManage.adapter.StaffRequestDiffCallback
 
-class StaffRequestAdapter(private val items: List<String>) :
-    RecyclerView.Adapter<StaffRequestAdapter.RequestViewHolder>() {
+
+class StaffRequestAdapter(
+    private val onApprove: (Long) -> Unit,
+    private val onReject: (Long) -> Unit
+) : ListAdapter<PendingStaffItem, StaffRequestAdapter.RequestViewHolder>(
+    StaffRequestDiffCallback
+) {
 
     inner class RequestViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val text = itemView.findViewById<TextView>(android.R.id.text1)
+        val tvName: TextView = itemView.findViewById(R.id.tvStaffName)
+        val tvPhone: TextView = itemView.findViewById(R.id.tvStaffPhone)
+        val btnApprove: MaterialButton = itemView.findViewById(R.id.btnApprove)
+        val btnReject: MaterialButton = itemView.findViewById(R.id.btnReject)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RequestViewHolder {
         val view = LayoutInflater.from(parent.context)
-            .inflate(android.R.layout.simple_list_item_1, parent, false)
+            .inflate(R.layout.item_staff_request, parent, false)
         return RequestViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: RequestViewHolder, position: Int) {
-        holder.text.text = items[position]
-    }
+        val item = getItem(position)
 
-    override fun getItemCount() = items.size
+        holder.tvName.text = item.name
+        holder.tvPhone.text = item.phone
+
+        holder.btnApprove.setOnClickListener {
+            onApprove(item.staffId)
+        }
+
+        holder.btnReject.setOnClickListener {
+            onReject(item.staffId)
+        }
+    }
 }

--- a/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffRequestDiffCallback.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/adapter/StaffRequestDiffCallback.kt
@@ -1,0 +1,22 @@
+package com.example.bisit.ui.staffManage.adapter
+
+import androidx.recyclerview.widget.DiffUtil
+import com.example.bisit.data.model.staffManage.PendingStaffItem
+
+object StaffRequestDiffCallback : DiffUtil.ItemCallback<PendingStaffItem>() {
+
+    override fun areItemsTheSame(
+        oldItem: PendingStaffItem,
+        newItem: PendingStaffItem
+    ): Boolean {
+        // 같은 직원인지 판단 (고유 ID)
+        return oldItem.staffId == newItem.staffId
+    }
+
+    override fun areContentsTheSame(
+        oldItem: PendingStaffItem,
+        newItem: PendingStaffItem
+    ): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/modal/DeleteCompleteDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/modal/DeleteCompleteDialog.kt
@@ -1,0 +1,55 @@
+package com.example.bisit.ui.staffManage.modal
+
+import android.os.Build
+import android.os.Bundle
+import android.view.*
+import androidx.fragment.app.DialogFragment
+import com.example.bisit.databinding.DialogDeleteCompleteBinding
+
+class DeleteCompleteDialog(
+    private val onClose: (() -> Unit)? = null
+) : DialogFragment() {
+
+    private var _binding: DialogDeleteCompleteBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogDeleteCompleteBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.btnClose.setOnClickListener {
+            onClose?.invoke()
+            dismiss()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.apply {
+            setBackgroundDrawableResource(android.R.color.transparent)
+
+            val screenWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val wm = requireActivity().windowManager.currentWindowMetrics
+                val insets = wm.windowInsets.getInsets(WindowInsets.Type.systemBars())
+                wm.bounds.width() - insets.left - insets.right
+            } else {
+                resources.displayMetrics.widthPixels
+            }
+
+            setLayout((screenWidth * 0.806f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/modal/DeleteStaffDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/modal/DeleteStaffDialog.kt
@@ -1,0 +1,58 @@
+package com.example.bisit.ui.staffManage.modal
+
+import android.os.Build
+import android.os.Bundle
+import android.view.*
+import androidx.fragment.app.DialogFragment
+import com.example.bisit.databinding.DialogDeleteStaffBinding
+
+class DeleteStaffDialog(
+    private val onConfirm: () -> Unit
+) : DialogFragment() {
+
+    private var _binding: DialogDeleteStaffBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogDeleteStaffBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.btnCancel.setOnClickListener {
+            dismiss()
+        }
+
+        binding.btnOk.setOnClickListener {
+            onConfirm() // 삭제 실행만 위임
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.apply {
+            setBackgroundDrawableResource(android.R.color.transparent)
+
+            val screenWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val wm = requireActivity().windowManager.currentWindowMetrics
+                val insets = wm.windowInsets.getInsets(WindowInsets.Type.systemBars())
+                wm.bounds.width() - insets.left - insets.right
+            } else {
+                resources.displayMetrics.widthPixels
+            }
+
+            setLayout((screenWidth * 0.806f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/staffManage/modal/StaffRequestResultDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/modal/StaffRequestResultDialog.kt
@@ -1,0 +1,56 @@
+package com.example.bisit.ui.staffManage.modal
+
+import android.os.Build
+import android.os.Bundle
+import android.view.*
+import androidx.fragment.app.DialogFragment
+import com.example.bisit.databinding.DialogStaffRequestResultBinding
+
+class StaffRequestResultDialog(
+    private val message: String
+) : DialogFragment() {
+
+    private var _b: DialogStaffRequestResultBinding? = null
+    private val b get() = _b!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _b = DialogStaffRequestResultBinding.inflate(inflater, container, false)
+        return b.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        b.tvMessage.text = message
+        b.btnClose.setOnClickListener { dismiss() }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.apply {
+            // 배경 dim
+            setBackgroundDrawableResource(android.R.color.transparent)
+            setDimAmount(0.8f)
+
+            // width = 화면의 80.6%
+            val screenWidth =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    val wm = requireActivity().windowManager.currentWindowMetrics
+                    val insets = wm.windowInsets.getInsets(WindowInsets.Type.systemBars())
+                    wm.bounds.width() - insets.left - insets.right
+                } else {
+                    resources.displayMetrics.widthPixels
+                }
+
+            setLayout((screenWidth * 0.806f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _b = null
+    }
+}

--- a/app/src/main/res/layout/dialog_delete_complete.xml
+++ b/app/src/main/res/layout/dialog_delete_complete.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 직원 삭제 완료 모달 -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:background="@drawable/bg_card_white"
+    android:padding="15dp">
+
+    <TextView
+        android:id="@+id/tvMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="삭제되었습니다."
+        android:textColor="#222222"
+        android:textSize="16sp"
+        android:letterSpacing="0"
+        android:layout_marginTop="17dp"
+        android:layout_marginBottom="20dp" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btnClose"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:text="닫기"
+        android:textColor="#6D7583"
+        android:textSize="14sp"
+        android:background="@drawable/bg_button_gray_light"
+        android:stateListAnimator="@null"
+        android:gravity="center"
+        android:enabled="true" />
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_delete_staff.xml
+++ b/app/src/main/res/layout/dialog_delete_staff.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="24dp"
+    android:paddingBottom="20dp"
+    android:paddingStart="20dp"
+    android:paddingEnd="20dp"
+    android:background="@drawable/bg_card_white">
+
+    <!-- 제목 -->
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="직원을 삭제하시겠어요?"
+        android:textColor="#222222"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:gravity="center" />
+
+    <!-- 설명 -->
+    <TextView
+        android:id="@+id/tvDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="삭제 후 복구가 불가능합니다."
+        android:textColor="#515965"
+        android:textSize="14sp"
+        android:gravity="center"
+        android:layout_marginTop="6dp" />
+
+    <!-- 버튼 영역 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="20dp">
+
+        <!-- 닫기 -->
+        <TextView
+            android:id="@+id/btnCancel"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="닫기"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:textColor="#515965"
+            android:background="@drawable/bg_chip_selector" />
+
+        <Space
+            android:layout_width="12dp"
+            android:layout_height="0dp" />
+
+        <!-- 삭제하기 -->
+        <TextView
+            android:id="@+id/btnOk"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="삭제하기"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:textColor="#FFFFFF"
+            android:background="@drawable/bg_btn_primary_selector" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_staff_request_result.xml
+++ b/app/src/main/res/layout/dialog_staff_request_result.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 직원 삭제 완료 모달 -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:background="@drawable/bg_card_white"
+    android:padding="15dp">
+
+    <TextView
+        android:id="@+id/tvMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="직원 요청이 승인되었습니다."
+        android:textColor="#222222"
+        android:textSize="16sp"
+        android:letterSpacing="0"
+        android:layout_marginTop="17dp"
+        android:layout_marginBottom="20dp" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btnClose"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:text="닫기"
+        android:textColor="#6D7583"
+        android:textSize="14sp"
+        android:background="@drawable/bg_button_gray_light"
+        android:stateListAnimator="@null"
+        android:gravity="center"
+        android:enabled="true" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_reserv_list.xml
+++ b/app/src/main/res/layout/item_reserv_list.xml
@@ -30,25 +30,25 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="예약 확정"
-                android:textColor="#FE6B6B"
+                android:textColor="#4076FF"
                 android:textSize="14sp"
                 android:textStyle="bold" />
 
-            <!-- 구분선 | -->
-            <View
-                android:layout_width="1dp"
-                android:layout_height="8dp"
-                android:layout_marginStart="10dp"
-                android:layout_marginEnd="6dp"
-                android:background="#D7DBDF" />
+<!--            &lt;!&ndash; 구분선 | &ndash;&gt;-->
+<!--            <View-->
+<!--                android:layout_width="1dp"-->
+<!--                android:layout_height="8dp"-->
+<!--                android:layout_marginStart="10dp"-->
+<!--                android:layout_marginEnd="6dp"-->
+<!--                android:background="#D7DBDF" />-->
 
-            <TextView
-                android:id="@+id/tvProcedureStatus"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="시술 전"
-                android:textColor="#9AA1AF"
-                android:textSize="14sp" />
+<!--            <TextView-->
+<!--                android:id="@+id/tvProcedureStatus"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:text="시술 전"-->
+<!--                android:textColor="#9AA1AF"-->
+<!--                android:textSize="14sp" />-->
         </LinearLayout>
 
         <TextView

--- a/app/src/main/res/layout/item_reservation.xml
+++ b/app/src/main/res/layout/item_reservation.xml
@@ -120,7 +120,7 @@
             android:id="@+id/btnApprove"
             android:text="@string/today_button_approve"
             android:textColor="#FFFFFF"
-            app:backgroundTint="#FE6B6B"
+            app:backgroundTint="#4076FF"
             android:stateListAnimator="@null"
             app:cornerRadius="8dp"
             android:insetTop="0dp"

--- a/app/src/main/res/layout/item_staff_list.xml
+++ b/app/src/main/res/layout/item_staff_list.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingHorizontal="20dp"
+    android:paddingVertical="18dp"
+    android:layout_marginBottom="8dp"
+    android:background="@drawable/bg_dialog_white">
+
+    <!-- 왼쪽: 직원 + 이름 -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <!-- 직원 라벨 -->
+        <TextView
+            android:id="@+id/tvStaffLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="직원"
+            android:textColor="#9AA1AF"
+            android:textSize="11sp" />
+
+        <!-- 직원 이름 -->
+        <TextView
+            android:id="@+id/tvStaffName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:text="김OO"
+            android:textColor="#222222"
+            android:textSize="15sp" />
+    </LinearLayout>
+
+    <!-- 오른쪽: 삭제 버튼 -->
+    <TextView
+        android:id="@+id/btnStaffDelete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/delete_underlined"
+        android:textColor="#F54343"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        android:gravity="center" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_staff_request.xml
+++ b/app/src/main/res/layout/item_staff_request.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_marginBottom="8dp"
+    android:background="@drawable/bg_card_white"
+    android:paddingTop="24dp"
+    android:paddingBottom="15dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <!-- ===== 상단 정보 영역 ===== -->
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_marginHorizontal="20dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <!-- 이름 -->
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/labelName"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content"
+                android:text="이름"
+                android:textColor="#9AA1AF"
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/tvStaffName"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:text="김OO"
+                android:textColor="#222222"
+                android:textSize="14sp" />
+        </LinearLayout>
+
+        <!-- 전화번호 -->
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/labelPhone"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content"
+                android:text="전화번호"
+                android:textColor="#9AA1AF"
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/tvStaffPhone"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:text="010-0000-0000"
+                android:textColor="#222222"
+                android:textSize="14sp" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- ===== 버튼 영역 ===== -->
+    <LinearLayout
+        android:layout_marginTop="23dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <!-- 거절 -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnReject"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_weight="1"
+            android:text="거절하기"
+            android:textColor="#515965"
+            android:textSize="15sp"
+            android:stateListAnimator="@null"
+            app:backgroundTint="#F0F2F5"
+            app:cornerRadius="8dp"
+            android:insetTop="0dp"
+            android:insetBottom="0dp" />
+
+        <View
+            android:layout_width="10dp"
+            android:layout_height="0dp" />
+
+        <!-- 승인 -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnApprove"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_weight="1"
+            android:text="승인하기"
+            android:textColor="#FFFFFF"
+            android:textSize="15sp"
+            android:stateListAnimator="@null"
+            app:backgroundTint="#4076FF"
+            app:cornerRadius="8dp"
+            android:insetTop="0dp"
+            android:insetBottom="0dp" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,4 +225,7 @@
         vestibulum. Fusce dictum libero quis erat maximus, vitae volutpat diam dignissim.
     </string>
 
+    <!--직원 삭제-->
+    <string name="delete_underlined"><u>삭제</u></string>
+
 </resources>


### PR DESCRIPTION
## ✔️ 작업 내용 (Summary)
- 가게 직원 관리 기능 전반을 구현하고, 
- 직원 신청 → 승인/거절 → 승인된 직원 목록 조회 → 직원 삭제까지의 전체 플로우를 ViewModel 기반으로 연결했습니다.

- 각 사용자 액션 이후 명확한 피드백을 제공하기 위해 결과 모달 UI를 추가하여 서버 처리 결과를 사용자가 직관적으로 인지할 수 있도록 개선했습니다.

## 🔗 API 연동 내역
- 직원 신청 목록 조회 API 연동
- 직원 승인 API 연동
- 직원 거절 API 연동
- 승인된 직원 목록 조회 API 연동
- 직원 삭제 API 연동

> 모든 API 호출은 `StaffManageRepository`를 통해 관리하며,  
> Fragment는 ViewModel 상태만 관찰하도록 구조를 분리했습니다.

## 🧭 화면 흐름 정리
### 1. 직원 신청 목록 화면
- 직원 신청 목록 조회
- 승인 / 거절 버튼 클릭 시 API 호출
- 처리 완료 후 결과 모달 노출

### 2. 직원 목록 화면
- 승인된 직원 목록 조회
- 삭제 버튼 클릭 시 확인 모달 표시
- 삭제 확정 시 리스트 즉시 반영
- 삭제 완료 모달 표시 후 화면 유지

## 🧩 구조 및 설계 포인트
- ViewModel + StateFlow 기반 상태 관리
- Fragment 간 상태 공유를 위해 `activityViewModels` 사용
- RecyclerView는 `ListAdapter + DiffUtil` 적용
- `notifyDataSetChanged` 사용을 지양하고 변경된 아이템만 갱신

## 🎯 UX 개선 사항
- 승인 / 거절 / 삭제 결과를 명확히 전달하기 위한 결과 모달 추가
- 모달 dim 처리(0.8f)로 사용자 집중도 강화
- 서버 반영과 UI 반영 시점을 분리하여 안정적인 UX 제공

## 🛠️ 구현 과정에서 고민한 부분
- Fragment에서 직접 API 호출 vs ViewModel 위임 구조 선택
- 삭제 즉시 반영과 사용자 인지 사이의 UX 균형
- RecyclerView 성능 개선을 위한 DiffUtil 적용 타이밍

## 🚀 개선 및 확장 가능 포인트
- 승인/거절/삭제 실패 시 에러 상태 분기 처리
- 정렬 기준 API 연동
- 로딩 상태 UI 추가
- 메시지 리소스 분리 및 다국어 대응

## 📷 스크린샷
- 직원 신청 목록 화면  
- 승인/거절 결과 모달  
- 직원 목록 화면  
- 직원 삭제 확인 및 완료 모달  

## 💬 참고 사항 (Reviewer Notes)
- 직원 관리 기능은 추후 다른 관리 기능에서도 재사용할 수 있도록 구조를 통일했습니다.
- 사용자 액션 → 서버 처리 → UI 피드백 흐름을 명확히 하는 데 중점을 두었습니다.
- 이후 서버 응답 확장에 따라 에러 처리 및 로딩 UI를 보완할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 직원 관리 시스템 추가 - 직원 추가, 삭제, 승인, 거절 기능 지원
  * 보류 중인 직원과 승인된 직원 목록 조회 기능
  * 직원 삭제 시 확인 대화상자 및 완료 알림 제공

* **디자인**
  * 직원 관리 관련 새로운 UI 화면 추가
  * 예약 상태 표시 색상 업데이트 (#FE6B6B → #4076FF)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->