### PR TITLE
[Feature/#77] 사장님 매장관리 공지사항 API 연동

### DIFF
--- a/app/src/main/java/com/example/bisit/data/api/RetrofitClient.kt
+++ b/app/src/main/java/com/example/bisit/data/api/RetrofitClient.kt
@@ -143,4 +143,6 @@ object RetrofitClient {
     fun getShopRegisterApi(context: Context) =
         getServerRetrofit(context).create(ShopRegisterApiService::class.java)
 
+    fun getShopNoticeApi(context: Context) =
+        getServerRetrofit(context).create(ShopNoticeApiService::class.java)
 }

--- a/app/src/main/java/com/example/bisit/data/api/ShopNoticeApiService.kt
+++ b/app/src/main/java/com/example/bisit/data/api/ShopNoticeApiService.kt
@@ -1,0 +1,37 @@
+package com.example.bisit.data.api
+
+import com.example.bisit.data.model.shop.*
+import retrofit2.Response
+import retrofit2.http.*
+
+interface ShopNoticeApiService {
+
+    /** 공지사항 목록 조회 */
+    @GET("/api/shops/{shopId}/notices")
+    suspend fun getShopNotices(
+        @Path("shopId") shopId: Long,
+        @Query("sortOrder") sortOrder: String = "desc"
+    ): Response<ApiResponse<ShopNoticeListResponse>>
+
+    /** 공지사항 생성 */
+    @POST("/api/shops/{shopId}/notices")
+    suspend fun createShopNotice(
+        @Path("shopId") shopId: Long,
+        @Body request: ShopNoticeRequest
+    ): Response<ApiResponse<ShopNoticeResponse>>
+
+    /** 공지사항 수정 */
+    @PUT("/api/shops/{shopId}/notices/{noticeId}")
+    suspend fun updateShopNotice(
+        @Path("shopId") shopId: Long,
+        @Path("noticeId") noticeId: Long,
+        @Body request: ShopNoticeRequest
+    ): Response<ApiResponse<ShopNoticeResponse>>
+
+    /** 공지사항 삭제 */
+    @DELETE("/api/shops/{shopId}/notices/{noticeId}")
+    suspend fun deleteShopNotice(
+        @Path("shopId") shopId: Long,
+        @Path("noticeId") noticeId: Long
+    ): Response<ApiResponse<String>>
+}

--- a/app/src/main/java/com/example/bisit/data/model/shop/ShopNoticeModels.kt
+++ b/app/src/main/java/com/example/bisit/data/model/shop/ShopNoticeModels.kt
@@ -1,0 +1,28 @@
+package com.example.bisit.data.model.shop
+
+/** 공통 API 응답 */
+data class ApiResponse<T>(
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: T
+)
+
+/** 공지사항 단건 */
+data class ShopNoticeResponse(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val createdAt: String
+)
+
+/** 공지사항 목록 */
+data class ShopNoticeListResponse(
+    val notices: List<ShopNoticeResponse>
+)
+
+/** 생성 / 수정 요청 */
+data class ShopNoticeRequest(
+    val title: String,
+    val content: String
+)

--- a/app/src/main/java/com/example/bisit/data/repository/shop/ShopNoticeRepository.kt
+++ b/app/src/main/java/com/example/bisit/data/repository/shop/ShopNoticeRepository.kt
@@ -1,0 +1,54 @@
+package com.example.bisit.data.repository.shop
+
+import android.content.Context
+import com.example.bisit.data.api.ShopNoticeApiService
+import com.example.bisit.data.model.shop.*
+import com.example.bisit.data.api.RetrofitClient
+
+class ShopNoticeRepository(context: Context) {
+
+    private val api: ShopNoticeApiService =
+        RetrofitClient.getShopNoticeApi(context)
+
+    suspend fun getNotices(
+        shopId: Long,
+        sortOrder: String = "desc"
+    ): ApiResponse<ShopNoticeListResponse>? {
+        val response = api.getShopNotices(shopId, sortOrder)
+        return if (response.isSuccessful) response.body() else null
+    }
+
+    suspend fun createNotice(
+        shopId: Long,
+        title: String,
+        content: String
+    ): ApiResponse<ShopNoticeResponse>? {
+        val response = api.createShopNotice(
+            shopId,
+            ShopNoticeRequest(title, content)
+        )
+        return if (response.isSuccessful) response.body() else null
+    }
+
+    suspend fun updateNotice(
+        shopId: Long,
+        noticeId: Long,
+        title: String,
+        content: String
+    ): ApiResponse<ShopNoticeResponse>? {
+        val response = api.updateShopNotice(
+            shopId,
+            noticeId,
+            ShopNoticeRequest(title, content)
+        )
+        return if (response.isSuccessful) response.body() else null
+    }
+
+    suspend fun deleteNotice(
+        shopId: Long,
+        noticeId: Long
+    ): ApiResponse<String>? {
+        val response = api.deleteShopNotice(shopId, noticeId)
+        return if (response.isSuccessful) response.body() else null
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopNoticeViewModel.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopNoticeViewModel.kt
@@ -1,0 +1,88 @@
+package com.example.bisit.ui.shop
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.bisit.data.model.shop.ShopNoticeResponse
+import com.example.bisit.data.repository.shop.ShopNoticeRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class ShopNoticeViewModel(
+    private val repository: ShopNoticeRepository
+) : ViewModel() {
+
+    private val _notices = MutableStateFlow<List<ShopNoticeResponse>>(emptyList())
+    val notices: StateFlow<List<ShopNoticeResponse>> = _notices
+
+    private val _sortType = MutableStateFlow("recent") // recent | oldest
+    val sortType: StateFlow<String> = _sortType
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    /** ================= 조회 ================= */
+    fun loadNotices(shopId: Long) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorMessage.value = null
+
+            val sortOrder = if (_sortType.value == "recent") "desc" else "asc"
+
+            try {
+                val response = repository.getNotices(shopId, sortOrder)
+                if (response?.success == true) {
+                    _notices.value = response.data.notices
+                } else {
+                    _errorMessage.value = response?.message
+                }
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    /** ================= 정렬 ================= */
+    fun changeSort(shopId: Long, sort: String) {
+        _sortType.value = sort
+        loadNotices(shopId)
+    }
+
+    /** ================= 삭제 ================= */
+    fun deleteNotice(shopId: Long, noticeId: Long) {
+        viewModelScope.launch {
+            repository.deleteNotice(shopId, noticeId)
+            loadNotices(shopId)
+        }
+    }
+
+    /** ================= 추가 ================= */
+    fun createNotice(
+        shopId: Long,
+        title: String,
+        content: String
+    ) {
+        viewModelScope.launch {
+            repository.createNotice(shopId, title, content)
+            loadNotices(shopId)
+        }
+    }
+
+    /** ================= 수정 ================= */
+    fun updateNotice(
+        shopId: Long,
+        noticeId: Long,
+        title: String,
+        content: String
+    ) {
+        viewModelScope.launch {
+            repository.updateNotice(shopId, noticeId, title, content)
+            loadNotices(shopId)
+        }
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopNoticeViewModelFactory.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopNoticeViewModelFactory.kt
@@ -1,0 +1,20 @@
+package com.example.bisit.ui.shop
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.bisit.data.repository.shop.ShopNoticeRepository
+
+class ShopNoticeViewModelFactory(
+    private val context: Context
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ShopNoticeViewModel::class.java)) {
+            val repository = ShopNoticeRepository(context.applicationContext)
+            return ShopNoticeViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopNoticesFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopNoticesFragment.kt
@@ -5,6 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.bisit.databinding.FragmentShopNoticesBinding
 import com.example.bisit.ui.shop.adapter.NoticeAdapter
@@ -12,6 +15,8 @@ import com.example.bisit.ui.shop.dialog.AddNoticeDialog
 import com.example.bisit.ui.shop.dialog.BottomActionSheet
 import com.example.bisit.ui.shop.dialog.ConfirmDialog
 import com.example.bisit.ui.shop.model.Notice
+import com.example.bisit.ui.todayReserv.dialog.SortOptionDialog
+import kotlinx.coroutines.launch
 
 class ShopNoticesFragment : Fragment() {
 
@@ -20,10 +25,13 @@ class ShopNoticesFragment : Fragment() {
 
     private lateinit var adapter: NoticeAdapter
 
-    private val data = mutableListOf(
-        Notice(1, "개인 사정으로 휴무입니다.", "09/13 금요일은 개인 사정으로 휴무입니다.", "2025.09.13"),
-        Notice(2, "광복절 휴무입니다.", "공휴일 운영안내: 일정 공지", "2025.08.15")
-    )
+    /** shopId 제공용 */
+    private val shopRegisterViewModel: ShopRegisterViewModel by activityViewModels()
+
+    /** 공지사항 전용 ViewModel */
+    private val noticeViewModel: ShopNoticeViewModel by viewModels {
+        ShopNoticeViewModelFactory(requireContext())
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -37,6 +45,15 @@ class ShopNoticesFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        setupRecyclerView()
+        observeViewModel()
+        setupSort()
+        setupAddNotice()
+    }
+
+    /** ================= RecyclerView ================= */
+
+    private fun setupRecyclerView() {
         adapter = NoticeAdapter { notice ->
             BottomActionSheet().show(parentFragmentManager, "actions")
 
@@ -48,18 +65,23 @@ class ShopNoticesFragment : Fragment() {
 
                     BottomActionSheet.ACTION_DELETE -> {
                         ConfirmDialog("삭제하시겠어요?") {
-                            data.removeAll { it.id == notice.id }
-                            adapter.submitList(data.toList())
+                            val shopId =
+                                shopRegisterViewModel.shopId.value ?: return@ConfirmDialog
+                            noticeViewModel.deleteNotice(shopId, notice.id)
                         }.show(parentFragmentManager, "confirm")
                     }
 
                     BottomActionSheet.ACTION_EDIT -> {
                         AddNoticeDialog(prefill = notice) { updated ->
-                            val idx = data.indexOfFirst { it.id == updated.id }
-                            if (idx != -1) {
-                                data[idx] = updated
-                                adapter.submitList(data.toList())
-                            }
+                            val shopId =
+                                shopRegisterViewModel.shopId.value ?: return@AddNoticeDialog
+
+                            noticeViewModel.updateNotice(
+                                shopId = shopId,
+                                noticeId = updated.id,
+                                title = updated.title,
+                                content = updated.content
+                            )
                         }.show(parentFragmentManager, "edit_notice")
                     }
                 }
@@ -68,13 +90,64 @@ class ShopNoticesFragment : Fragment() {
 
         binding.rvNotices.layoutManager = LinearLayoutManager(requireContext())
         binding.rvNotices.adapter = adapter
-        adapter.submitList(data.toList())
+    }
 
+    /** ================= ViewModel Observe ================= */
+
+    private fun observeViewModel() {
+        // shopId 수신 → 공지사항 로드
+        viewLifecycleOwner.lifecycleScope.launch {
+            shopRegisterViewModel.shopId.collect { shopId ->
+                if (shopId != null) {
+                    noticeViewModel.loadNotices(shopId)
+                }
+            }
+        }
+
+        // 공지사항 리스트 반영
+        viewLifecycleOwner.lifecycleScope.launch {
+            noticeViewModel.notices.collect { list ->
+                adapter.submitList(
+                    list.map {
+                        Notice(
+                            id = it.id,
+                            title = it.title,
+                            content = it.content,
+                            date = it.createdAt.substring(0, 10)
+                        )
+                    }
+                )
+            }
+        }
+    }
+
+    /** ================= 정렬 ================= */
+
+    private fun setupSort() {
+        binding.tvSortLabel.setOnClickListener {
+            SortOptionDialog(
+                currentSort = noticeViewModel.sortType.value
+            ) { selected ->
+                val shopId =
+                    shopRegisterViewModel.shopId.value ?: return@SortOptionDialog
+                noticeViewModel.changeSort(shopId, selected)
+            }.show(parentFragmentManager, "sort_option")
+        }
+    }
+
+    /** ================= 공지 추가 ================= */
+
+    private fun setupAddNotice() {
         binding.fabAdd.setOnClickListener {
             AddNoticeDialog { newItem ->
-                val newId = (data.maxOfOrNull { it.id } ?: 0) + 1
-                data.add(newItem.copy(id = newId))
-                adapter.submitList(data.toList())
+                val shopId =
+                    shopRegisterViewModel.shopId.value ?: return@AddNoticeDialog
+
+                noticeViewModel.createNotice(
+                    shopId = shopId,
+                    title = newItem.title,
+                    content = newItem.content
+                )
             }.show(parentFragmentManager, "add_notice")
         }
     }


### PR DESCRIPTION
## ✔️ 작업 내용
- 매장 관리자 공지사항 관리 기능(API 연동) 구현
- 공지사항 **조회 / 생성 / 수정 / 삭제(CRUD)** 전체 플로우 완성
- shopId를 단일 소스로 관리하여 공지사항 API 호출 구조 통합
- BottomSheet + Dialog 기반의 공지사항 수정/삭제 UX 구현
- 최신순 / 오래된순 **정렬 기준 선택 기능** 연동 (서버 정렬 기준 사용)
- MVVM 구조에 맞게 Fragment / ViewModel / Repository 책임 분리

## 🔨 상세 구현 내용
- `ShopNoticeRepository`를 통해 공지사항 API CRUD 처리
- `ShopNoticeViewModel`에서 상태(StateFlow) 기반 공지사항 리스트 및 정렬 상태 관리
- `ShopNoticesFragment`에서 UI 이벤트만 처리하도록 역할 최소화
- 공지사항 생성/수정 후 서버 재조회 방식으로 리스트 동기화
- `FragmentResultListener`를 활용하여 BottomActionSheet 액션 처리

## ✨ 개선점
- Fragment에서 직접 리스트를 조작하던 구조를 제거하고  
  ViewModel을 단일 진실 소스로 사용하도록 개선
- 정렬 로직을 클라이언트 기준이 아닌 **서버 기준 정렬 파라미터**로 통합하여
  데이터 신뢰성 및 유지보수성 향상
- 공지사항 생성/수정 Dialog를 재사용 가능하도록 분리하여
  UI 중복 코드 최소화
- DiffUtil 기반 ListAdapter 사용으로 RecyclerView 성능 개선

## ⚠️ 어려웠던 점
- shopId가 여러 화면에서 사용되는 구조라  
  ViewModel 간 데이터 흐름을 정리하는 데 시간이 필요했음
- Fragment ↔ ViewModel ↔ Repository 역할 경계를 명확히 나누는 과정에서  
  함수 책임 범위를 여러 차례 재정의함
- BottomSheet + Dialog + FragmentResultListener 조합에서  
  생명주기 이슈 없이 이벤트를 전달하는 구조를 잡는 것이 까다로웠음

## 📷 스크린샷
- 공지사항 목록 화면
- 공지사항 추가/수정 Dialog
- 공지사항 정렬 옵션 선택 Dialog
- 공지사항 수정/삭제 BottomSheet

## 💬 참고 사항
- 공지사항 생성/수정/삭제 후에는 서버 데이터를 기준으로 재조회하도록 구현되어 있습니다.
- 현재 로딩/에러 상태는 ViewModel에 정의되어 있으며,  
  추후 Skeleton UI 및 공통 에러 처리 UI로 확장 가능하도록 구조를 잡아두었습니다.
- MVVM 패턴 및 기존 프로젝트 구조를 최대한 유지하는 방향으로 구현했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* 상점 공지사항 관리 기능 추가: 상점의 공지사항을 조회하고, 새로운 공지사항을 작성하며, 기존 공지사항을 수정하고 삭제할 수 있습니다.
* 공지사항 정렬 옵션 추가: 최신순 또는 오래된순으로 공지사항을 정렬하여 관리할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->