### PR TITLE
[Feature/#78] 사장님 매장관리 리뷰 API

### DIFF
--- a/app/src/main/java/com/example/bisit/data/api/RetrofitClient.kt
+++ b/app/src/main/java/com/example/bisit/data/api/RetrofitClient.kt
@@ -162,4 +162,7 @@ object RetrofitClient {
 
     fun getReservationListApi(context: Context) =
         getServerRetrofit(context).create(ReservListApiService::class.java)
+
+    fun getReviewManageApi(context: Context) =
+        getServerRetrofit(context).create(ReviewManageApi::class.java)
 }

--- a/app/src/main/java/com/example/bisit/data/api/ReviewManageApiService.kt
+++ b/app/src/main/java/com/example/bisit/data/api/ReviewManageApiService.kt
@@ -1,0 +1,25 @@
+package com.example.bisit.data.api
+
+import com.example.bisit.data.model.shop.*
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface ReviewManageApi {
+
+    /** 매장 관리자용 리뷰 목록 조회 */
+    @GET("/api/reviews/shops/{shopId}/owner")
+    suspend fun getShopReviews(
+        @Path("shopId") shopId: Long,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 10
+    ): ReviewResponse
+
+    /** 매장 관리자용 리뷰 삭제 */
+    @DELETE("/api/reviews/{reviewId}/shops/{shopId}/owner")
+    suspend fun deleteReview(
+        @Path("reviewId") reviewId: Long,
+        @Path("shopId") shopId: Long
+    ): BaseDeleteResponse
+}

--- a/app/src/main/java/com/example/bisit/data/model/shop/BaseDeleteResponse.kt
+++ b/app/src/main/java/com/example/bisit/data/model/shop/BaseDeleteResponse.kt
@@ -1,0 +1,8 @@
+package com.example.bisit.data.model.shop
+
+data class BaseDeleteResponse(
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: String
+)

--- a/app/src/main/java/com/example/bisit/data/model/shop/ReviewManageItem.kt
+++ b/app/src/main/java/com/example/bisit/data/model/shop/ReviewManageItem.kt
@@ -1,0 +1,14 @@
+package com.example.bisit.data.model.shop
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class ReviewManageItem(
+    val serviceName: String,
+    val staffName: String,
+    val rating: Int,
+    val content: String,
+    val visitDate: LocalDate,
+    val reviewerName: String,
+    val createdAt: LocalDateTime
+)

--- a/app/src/main/java/com/example/bisit/data/model/shop/ReviewManageItem.kt
+++ b/app/src/main/java/com/example/bisit/data/model/shop/ReviewManageItem.kt
@@ -1,14 +1,12 @@
 package com.example.bisit.data.model.shop
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-
 data class ReviewManageItem(
+    val reviewId: Long,
     val serviceName: String,
     val staffName: String,
     val rating: Int,
     val content: String,
-    val visitDate: LocalDate,
+    val visitDate: String,
     val reviewerName: String,
-    val createdAt: LocalDateTime
+    val createdAt: String
 )

--- a/app/src/main/java/com/example/bisit/data/model/shop/ReviewPage.kt
+++ b/app/src/main/java/com/example/bisit/data/model/shop/ReviewPage.kt
@@ -1,0 +1,10 @@
+package com.example.bisit.data.model.shop
+
+data class ReviewPage(
+    val content: List<ReviewManageItem>,
+    val totalPages: Int,
+    val totalElements: Int,
+    val currentPage: Int,
+    val size: Int,
+    val hasNext: Boolean
+)

--- a/app/src/main/java/com/example/bisit/data/model/shop/ReviewResponse.kt
+++ b/app/src/main/java/com/example/bisit/data/model/shop/ReviewResponse.kt
@@ -1,0 +1,12 @@
+package com.example.bisit.data.model.shop
+
+data class ReviewResponse(
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: ReviewData
+)
+
+data class ReviewData(
+    val reviews: ReviewPage
+)

--- a/app/src/main/java/com/example/bisit/data/repository/shop/ReviewManageRepository.kt
+++ b/app/src/main/java/com/example/bisit/data/repository/shop/ReviewManageRepository.kt
@@ -1,0 +1,40 @@
+package com.example.bisit.data.repository.shop
+
+import android.content.Context
+import com.example.bisit.data.api.RetrofitClient
+import com.example.bisit.data.model.shop.ReviewPage
+
+class ReviewManageRepository(
+    context: Context
+) {
+
+    private val reviewManageApi =
+        RetrofitClient.getReviewManageApi(context)
+
+    /** 매장 관리자 리뷰 목록 조회 */
+    suspend fun fetchShopReviews(
+        shopId: Long,
+        page: Int = 0,
+        size: Int = 10
+    ): ReviewPage {
+        return reviewManageApi
+            .getShopReviews(
+                shopId = shopId,
+                page = page,
+                size = size
+            )
+            .data
+            .reviews
+    }
+
+    /** 매장 관리자 리뷰 삭제 */
+    suspend fun deleteReview(
+        shopId: Long,
+        reviewId: Long
+    ) {
+        reviewManageApi.deleteReview(
+            reviewId = reviewId,
+            shopId = shopId
+        )
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/customerShop/CustomerShopDetailAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/customerShop/CustomerShopDetailAdapter.kt
@@ -14,7 +14,6 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.example.bisit.R
 import com.example.bisit.data.model.shop.ServiceItem
-import com.example.bisit.data.model.shop.ReviewItem
 import com.example.bisit.data.model.customerShop.CustomerShopUiItem
 import com.example.bisit.databinding.DialogCopyAddressBinding
 import com.example.bisit.databinding.ItemShopDetailBinding

--- a/app/src/main/java/com/example/bisit/ui/customerShop/CustomerShopFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/customerShop/CustomerShopFragment.kt
@@ -17,7 +17,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.bisit.R
 import com.example.bisit.data.model.customerShop.BusinessHourItem
-import com.example.bisit.data.model.shop.ReviewItem
 import com.example.bisit.data.model.shop.ServiceItem
 import com.example.bisit.data.model.shop.ShopDetailItem
 import com.example.bisit.data.repository.customerShop.CustomerShopRepository

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.bisit.databinding.FragmentShopReviewsBinding
@@ -21,13 +22,13 @@ class ShopReviewsFragment : Fragment() {
 
     private lateinit var adapter: ReviewAdapter
 
-    // shopId 제공 VM
-    private val shopRegisterViewModel: ShopRegisterViewModel by activityViewModels()
+    private val shopRegisterViewModel: ShopRegisterViewModel by activityViewModels {
+        ShopRegisterViewModelFactory(requireContext().applicationContext)
+    }
 
-    // 리뷰 관리 VM
-    private lateinit var shopReviewsViewModel: ShopReviewsViewModel
+    private val shopReviewsViewModel: ShopReviewsViewModel by viewModels()
 
-    // 삭제 대상 리뷰 ID
+    /** 삭제 대상 리뷰 ID */
     private var selectedReviewId: Long? = null
 
     override fun onCreateView(
@@ -42,8 +43,6 @@ class ShopReviewsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        shopReviewsViewModel = ShopReviewsViewModel(requireContext())
-
         setupRecyclerView()
         observeShopId()
         observeViewModel()
@@ -55,7 +54,6 @@ class ShopReviewsFragment : Fragment() {
     private fun setupRecyclerView() {
         adapter = ReviewAdapter(
             onMoreClick = { review ->
-                // 삼 점 클릭 → 삭제 BottomSheet
                 selectedReviewId = review.reviewId
                 BottomActionSheet
                     .newInstance(BottomActionSheet.TYPE_REVIEW)
@@ -68,34 +66,30 @@ class ShopReviewsFragment : Fragment() {
     }
 
     /* ===================== shopId 연결 ===================== */
+
     private fun observeShopId() {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             shopRegisterViewModel.shopId.collect { shopId ->
                 shopId?.let {
-                    shopReviewsViewModel.initShop(it)
+                    shopReviewsViewModel.setShopId(it)
+                    shopReviewsViewModel.fetchReviews()
                 }
             }
         }
     }
 
     /* ===================== ViewModel 관찰 ===================== */
+
     private fun observeViewModel() {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             shopReviewsViewModel.reviews.collect { reviews ->
                 adapter.submitList(reviews)
             }
         }
 
-        lifecycleScope.launch {
-            shopReviewsViewModel.isLoading.collect { isLoading ->
-                binding.progressBar.visibility =
-                    if (isLoading) View.VISIBLE else View.GONE
-            }
-        }
-
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             shopReviewsViewModel.errorMessage.collect { message ->
-                // TODO: Snackbar / Toast 처리 가능
+                // TODO: Snackbar 또는 Toast 처리
             }
         }
     }
@@ -121,7 +115,6 @@ class ShopReviewsFragment : Fragment() {
         val reviewId = selectedReviewId ?: return
 
         ConfirmDialog(
-            title = "리뷰 삭제",
             message = "해당 리뷰를 삭제하시겠습니까?",
             onConfirm = {
                 shopReviewsViewModel.deleteReview(reviewId)

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsFragment.kt
@@ -5,21 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.bisit.databinding.FragmentShopReviewsBinding
 import com.example.bisit.ui.shop.adapter.ReviewAdapter
 import com.example.bisit.ui.shop.dialog.BottomActionSheet
 import com.example.bisit.ui.shop.dialog.ConfirmDialog
-import com.example.bisit.ui.todayReserv.dialog.SortOptionDialog
-import java.text.SimpleDateFormat
-import java.util.*
-
-import com.example.bisit.data.api.RetrofitClient
-import com.example.bisit.data.model.review.ReviewDetailItem
-import com.example.bisit.data.model.review.ReviewListResponse
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
+import kotlinx.coroutines.launch
 
 class ShopReviewsFragment : Fragment() {
 
@@ -28,9 +21,14 @@ class ShopReviewsFragment : Fragment() {
 
     private lateinit var adapter: ReviewAdapter
 
-    // No local data needed, will fetch from API
-    
-    private var currentSort: String = "recent"
+    // shopId 제공 VM
+    private val shopRegisterViewModel: ShopRegisterViewModel by activityViewModels()
+
+    // 리뷰 관리 VM
+    private lateinit var shopReviewsViewModel: ShopReviewsViewModel
+
+    // 삭제 대상 리뷰 ID
+    private var selectedReviewId: Long? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -44,57 +42,91 @@ class ShopReviewsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        adapter = ReviewAdapter(onMoreClick = { review ->
-            // Logic for more click, e.g., report?
-            // Shop reviews usually don't have delete/edit for the viewer unless it's their own or admin.
-            // Keeping existing structure but maybe disable actions if not owner.
-        })
+        shopReviewsViewModel = ShopReviewsViewModel(requireContext())
+
+        setupRecyclerView()
+        observeShopId()
+        observeViewModel()
+        observeBottomSheetResult()
+    }
+
+    /* ===================== RecyclerView ===================== */
+
+    private fun setupRecyclerView() {
+        adapter = ReviewAdapter(
+            onMoreClick = { review ->
+                // 삼 점 클릭 → 삭제 BottomSheet
+                selectedReviewId = review.reviewId
+                BottomActionSheet
+                    .newInstance(BottomActionSheet.TYPE_REVIEW)
+                    .show(parentFragmentManager, "bottom_action_sheet")
+            }
+        )
 
         binding.rvReviews.layoutManager = LinearLayoutManager(requireContext())
         binding.rvReviews.adapter = adapter
+    }
 
-        // Fetch Data
-        fetchReviews()
-
-        // 정렬 옵션 다이얼로그
-        binding.tvSortLabel.setOnClickListener {
-            SortOptionDialog(currentSort) { selectedSort ->
-                currentSort = selectedSort
-                binding.tvSortLabel.text =
-                    if (selectedSort == "recent") "최근 순으로" else "오래된 순으로"
-                
-                // Re-fetch or sorting logic if API supports sort
-                // API provided doesn't have sort param, assuming backend handles "recent" by default?
-                // Or client side sort? client side sort is hard with pagination.
-                // For now, re-fetch.
-                fetchReviews() 
-            }.show(parentFragmentManager, "sort_option")
+    /* ===================== shopId 연결 ===================== */
+    private fun observeShopId() {
+        lifecycleScope.launch {
+            shopRegisterViewModel.shopId.collect { shopId ->
+                shopId?.let {
+                    shopReviewsViewModel.initShop(it)
+                }
+            }
         }
     }
 
-    private fun fetchReviews() {
-        val shopId = arguments?.getLong("shopId") ?: 1L 
-        
-        RetrofitClient.getReviewApi(requireContext()).getShopReviews(shopId, 0, 10)
-            .enqueue(object : Callback<ReviewListResponse> {
-                override fun onResponse(
-                    call: Call<ReviewListResponse>,
-                    response: Response<ReviewListResponse>
-                ) {
-                    if (response.isSuccessful && response.body()?.success == true) {
-                        val reviewPage = response.body()?.data?.reviews
-                        val items = reviewPage?.content ?: emptyList()
-                        
-                        // Client side sort if needed or provided by API
-                        // The user said "리뷰는 최신순으로 정렬됩니다" (reviews are sorted by latest) by default.
-                        adapter.submitList(items)
-                    }
-                }
+    /* ===================== ViewModel 관찰 ===================== */
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            shopReviewsViewModel.reviews.collect { reviews ->
+                adapter.submitList(reviews)
+            }
+        }
 
-                override fun onFailure(call: Call<ReviewListResponse>, t: Throwable) {
-                    // Handle error
+        lifecycleScope.launch {
+            shopReviewsViewModel.isLoading.collect { isLoading ->
+                binding.progressBar.visibility =
+                    if (isLoading) View.VISIBLE else View.GONE
+            }
+        }
+
+        lifecycleScope.launch {
+            shopReviewsViewModel.errorMessage.collect { message ->
+                // TODO: Snackbar / Toast 처리 가능
+            }
+        }
+    }
+
+    /* ===================== BottomSheet 결과 ===================== */
+
+    private fun observeBottomSheetResult() {
+        parentFragmentManager.setFragmentResultListener(
+            BottomActionSheet.REQUEST_KEY,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            when (bundle.getString(BottomActionSheet.RESULT_ACTION)) {
+                BottomActionSheet.ACTION_DELETE -> {
+                    showDeleteConfirmDialog()
                 }
-            })
+            }
+        }
+    }
+
+    /* ===================== 삭제 확인 다이얼로그 ===================== */
+
+    private fun showDeleteConfirmDialog() {
+        val reviewId = selectedReviewId ?: return
+
+        ConfirmDialog(
+            title = "리뷰 삭제",
+            message = "해당 리뷰를 삭제하시겠습니까?",
+            onConfirm = {
+                shopReviewsViewModel.deleteReview(reviewId)
+            }
+        ).show(parentFragmentManager, "confirm_delete")
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsModel.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsModel.kt
@@ -1,0 +1,81 @@
+package com.example.bisit.ui.shop
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.bisit.data.model.shop.ReviewManageItem
+import com.example.bisit.data.repository.shop.ReviewManageRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class ShopReviewsViewModel(
+    context: Context
+) : ViewModel() {
+
+    private val repository = ReviewManageRepository(context)
+
+    /* ===================== shopId ===================== */
+
+    private var shopId: Long? = null
+
+    fun initShop(shopId: Long) {
+        if (this.shopId != null) return   // 중복 초기화 방지
+        this.shopId = shopId
+        loadReviews()
+    }
+
+    /* ===================== 리뷰 상태 ===================== */
+
+    private val _reviews = MutableStateFlow<List<ReviewManageItem>>(emptyList())
+    val reviews: StateFlow<List<ReviewManageItem>> = _reviews
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    /* ===================== 리뷰 조회 ===================== */
+
+    fun loadReviews(
+        page: Int = 0,
+        size: Int = 10
+    ) {
+        val id = shopId ?: return
+
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorMessage.value = null
+
+            runCatching {
+                repository.fetchShopReviews(id, page, size)
+            }.onSuccess { pageResult ->
+                _reviews.value = pageResult.content
+            }.onFailure { e ->
+                _errorMessage.value = e.message
+            }.also {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    /* ===================== 리뷰 삭제 ===================== */
+
+    fun deleteReview(reviewId: Long) {
+        val id = shopId ?: return
+
+        viewModelScope.launch {
+            runCatching {
+                repository.deleteReview(id, reviewId)
+            }.onSuccess {
+                // optimistic update
+                _reviews.value = _reviews.value.filterNot {
+                    it.hashCode() == reviewId.hashCode()
+                }
+            }.onFailure { e ->
+                _errorMessage.value = e.message
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsModel.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopReviewsModel.kt
@@ -1,7 +1,7 @@
 package com.example.bisit.ui.shop
 
-import android.content.Context
-import androidx.lifecycle.ViewModel
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.bisit.data.model.shop.ReviewManageItem
 import com.example.bisit.data.repository.shop.ReviewManageRepository
@@ -10,22 +10,25 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class ShopReviewsViewModel(
-    context: Context
-) : ViewModel() {
+    application: Application
+) : AndroidViewModel(application) {
 
-    private val repository = ReviewManageRepository(context)
+    private val reviewRepository = ReviewManageRepository(application)
 
     /* ===================== shopId ===================== */
 
-    private var shopId: Long? = null
+    private val _shopId = MutableStateFlow<Long?>(null)
 
-    fun initShop(shopId: Long) {
-        if (this.shopId != null) return   // 중복 초기화 방지
-        this.shopId = shopId
-        loadReviews()
+    fun setShopId(id: Long) {
+        _shopId.value = id
     }
 
-    /* ===================== 리뷰 상태 ===================== */
+    private fun requireShopId(): Long {
+        return _shopId.value
+            ?: throw IllegalStateException("shopId가 설정되지 않았습니다")
+    }
+
+    /* ===================== 상태 ===================== */
 
     private val _reviews = MutableStateFlow<List<ReviewManageItem>>(emptyList())
     val reviews: StateFlow<List<ReviewManageItem>> = _reviews
@@ -36,45 +39,54 @@ class ShopReviewsViewModel(
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage
 
-    /* ===================== 리뷰 조회 ===================== */
+    /* ===================== GET ===================== */
 
-    fun loadReviews(
+    fun fetchReviews(
         page: Int = 0,
         size: Int = 10
     ) {
-        val id = shopId ?: return
-
         viewModelScope.launch {
+            val shopId = requireShopId()
+
             _isLoading.value = true
             _errorMessage.value = null
 
-            runCatching {
-                repository.fetchShopReviews(id, page, size)
-            }.onSuccess { pageResult ->
+            try {
+                val pageResult = reviewRepository.fetchShopReviews(
+                    shopId = shopId,
+                    page = page,
+                    size = size
+                )
                 _reviews.value = pageResult.content
-            }.onFailure { e ->
+            } catch (e: Exception) {
                 _errorMessage.value = e.message
-            }.also {
+            } finally {
                 _isLoading.value = false
             }
         }
     }
 
-    /* ===================== 리뷰 삭제 ===================== */
+    /* ===================== DELETE ===================== */
 
     fun deleteReview(reviewId: Long) {
-        val id = shopId ?: return
-
         viewModelScope.launch {
-            runCatching {
-                repository.deleteReview(id, reviewId)
-            }.onSuccess {
-                // optimistic update
+            val shopId = requireShopId()
+
+            _isLoading.value = true
+            try {
+                reviewRepository.deleteReview(
+                    shopId = shopId,
+                    reviewId = reviewId
+                )
+
+                // optimistic update (reviewId 기준)
                 _reviews.value = _reviews.value.filterNot {
-                    it.hashCode() == reviewId.hashCode()
+                    it.reviewId == reviewId
                 }
-            }.onFailure { e ->
+            } catch (e: Exception) {
                 _errorMessage.value = e.message
+            } finally {
+                _isLoading.value = false
             }
         }
     }

--- a/app/src/main/java/com/example/bisit/ui/shop/adapter/ReviewAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/adapter/ReviewAdapter.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.bisit.R
 import com.example.bisit.data.model.shop.ReviewManageItem
 import com.example.bisit.databinding.ItemReviewBinding
+import com.example.bisit.util.DateFormatter
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -15,23 +16,28 @@ class ReviewAdapter(
     private val onMoreClick: (ReviewManageItem) -> Unit
 ) : ListAdapter<ReviewManageItem, ReviewAdapter.VH>(DIFF) {
 
-    companion object DIFF : DiffUtil.ItemCallback<ReviewManageItem>() {
-        override fun areItemsTheSame(
-            oldItem: ReviewManageItem,
-            newItem: ReviewManageItem
-        ): Boolean {
-            // reviewId가 있다면 그걸로 교체 권장
-            return oldItem.createdAt == newItem.createdAt
+    companion object {
+
+        private val DIFF = object : DiffUtil.ItemCallback<ReviewManageItem>() {
+            override fun areItemsTheSame(
+                oldItem: ReviewManageItem,
+                newItem: ReviewManageItem
+            ): Boolean {
+                return oldItem.reviewId == newItem.reviewId
+            }
+
+            override fun areContentsTheSame(
+                oldItem: ReviewManageItem,
+                newItem: ReviewManageItem
+            ): Boolean = oldItem == newItem
         }
 
-        override fun areContentsTheSame(
-            oldItem: ReviewManageItem,
-            newItem: ReviewManageItem
-        ): Boolean = oldItem == newItem
+        private val apiDateParser =
+            SimpleDateFormat("yyyy-MM-dd", Locale.KOREAN)
     }
 
-    inner class VH(val b: ItemReviewBinding) :
-        RecyclerView.ViewHolder(b.root)
+    inner class VH(val binding: ItemReviewBinding) :
+        RecyclerView.ViewHolder(binding.root)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
         return VH(
@@ -46,19 +52,24 @@ class ReviewAdapter(
     override fun onBindViewHolder(holder: VH, position: Int) {
         val item = getItem(position)
 
-        holder.b.apply {
+        holder.binding.apply {
 
-            // 날짜 (API 24 대응)
-            val dateString = item.visitDate.toString()
-            val date = java.sql.Date.valueOf(dateString)
-            val formatter = SimpleDateFormat("yyyy.MM.dd, E", Locale.KOREAN)
-            tvVisitDate.text = formatter.format(date) + " 방문"
+            // API 24 대응 날짜 처리
+            val parsedDate = apiDateParser.parse(item.visitDate)
+            val formattedDate = parsedDate?.let {
+                DateFormatter.formatReviewVisitDate(it)
+            } ?: ""
+
+            tvVisitDate.text =
+                root.context.getString(
+                    R.string.review_visit_date,
+                    formattedDate
+                )
 
             tvServiceName.text = item.serviceName
             tvCustomerName.text = item.reviewerName
             tvReviewContent.text = item.content
 
-            // 별점 처리
             val stars = listOf(star1, star2, star3, star4, star5)
             stars.forEachIndexed { index, imageView ->
                 imageView.setImageResource(

--- a/app/src/main/java/com/example/bisit/ui/shop/adapter/ReviewAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/adapter/ReviewAdapter.kt
@@ -5,39 +5,73 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.example.bisit.R
+import com.example.bisit.data.model.shop.ReviewManageItem
 import com.example.bisit.databinding.ItemReviewBinding
-import com.example.bisit.data.model.review.ReviewDetailItem
+import java.text.SimpleDateFormat
+import java.util.Locale
 
-class ReviewAdapter(private val onMoreClick: (ReviewDetailItem) -> Unit) :
-    ListAdapter<ReviewDetailItem, ReviewAdapter.VH>(DIFF) {
+class ReviewAdapter(
+    private val onMoreClick: (ReviewManageItem) -> Unit
+) : ListAdapter<ReviewManageItem, ReviewAdapter.VH>(DIFF) {
 
+    companion object DIFF : DiffUtil.ItemCallback<ReviewManageItem>() {
+        override fun areItemsTheSame(
+            oldItem: ReviewManageItem,
+            newItem: ReviewManageItem
+        ): Boolean {
+            // reviewId가 있다면 그걸로 교체 권장
+            return oldItem.createdAt == newItem.createdAt
+        }
 
-    companion object DIFF : DiffUtil.ItemCallback<ReviewDetailItem>() {
-        override fun areItemsTheSame(oldItem: ReviewDetailItem, newItem: ReviewDetailItem) = oldItem.reviewId == newItem.reviewId
-        override fun areContentsTheSame(oldItem: ReviewDetailItem, newItem: ReviewDetailItem) = oldItem == newItem
+        override fun areContentsTheSame(
+            oldItem: ReviewManageItem,
+            newItem: ReviewManageItem
+        ): Boolean = oldItem == newItem
     }
 
+    inner class VH(val b: ItemReviewBinding) :
+        RecyclerView.ViewHolder(b.root)
 
-    inner class VH(val b: ItemReviewBinding) : RecyclerView.ViewHolder(b.root)
-
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH =
-        VH(ItemReviewBinding.inflate(LayoutInflater.from(parent.context), parent, false))
-
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        return VH(
+            ItemReviewBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
 
     override fun onBindViewHolder(holder: VH, position: Int) {
         val item = getItem(position)
+
         holder.b.apply {
-            // Binding logic... assume views exist in XML
-            // TODO: Bind actual data if XML supports it. 
-            // For now binding simple fields if ID match or just passing click
-            
-            // Assuming simple binding for now as XML content wasn't fully inspected but required for adapter update
-            // tvAuthor.text = item.reviewerName
-            // tvContent.text = item.content
-            // ...
-            
-            btnMore.setOnClickListener { onMoreClick(item) }
+
+            // 날짜 (API 24 대응)
+            val dateString = item.visitDate.toString()
+            val date = java.sql.Date.valueOf(dateString)
+            val formatter = SimpleDateFormat("yyyy.MM.dd, E", Locale.KOREAN)
+            tvVisitDate.text = formatter.format(date) + " 방문"
+
+            tvServiceName.text = item.serviceName
+            tvCustomerName.text = item.reviewerName
+            tvReviewContent.text = item.content
+
+            // 별점 처리
+            val stars = listOf(star1, star2, star3, star4, star5)
+            stars.forEachIndexed { index, imageView ->
+                imageView.setImageResource(
+                    if (index < item.rating)
+                        R.drawable.ic_star_filled
+                    else
+                        R.drawable.ic_star_empty
+                )
+            }
+
+            btnMore.setOnClickListener {
+                onMoreClick(item)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/bisit/ui/shop/dialog/BottomActionSheet.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/dialog/BottomActionSheet.kt
@@ -19,8 +19,22 @@ class BottomActionSheet : BottomSheetDialogFragment() {
     companion object {
         const val REQUEST_KEY = "bottom_action_sheet"
         const val RESULT_ACTION = "action"
+
         const val ACTION_DELETE = "delete"
         const val ACTION_EDIT = "edit"
+
+        // 사용 타입
+        private const val ARG_TYPE = "type"
+        const val TYPE_REVIEW = "review"
+        const val TYPE_OTHER = "other"
+
+        fun newInstance(type: String): BottomActionSheet {
+            return BottomActionSheet().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_TYPE, type)
+                }
+            }
+        }
     }
 
     override fun getTheme(): Int = R.style.CustomBottomSheetTheme
@@ -28,11 +42,6 @@ class BottomActionSheet : BottomSheetDialogFragment() {
     private var _b: SheetActionsBinding? = null
     private val b get() = _b!!
 
-    /**
-     * BottomSheet 자체 설정
-     * - FULL HEIGHT
-     * - 위쪽만 둥근 배경 적용
-     */
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = BottomSheetDialog(requireContext(), theme)
 
@@ -42,10 +51,7 @@ class BottomActionSheet : BottomSheetDialogFragment() {
                     com.google.android.material.R.id.design_bottom_sheet
                 ) ?: return@setOnShowListener
 
-            // 전체 높이
             bottomSheet.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
-
-            // 둥근 배경은 여기서만 적용
             bottomSheet.setBackgroundResource(R.drawable.bg_bottom_sheet_top_round)
             bottomSheet.clipToOutline = true
 
@@ -69,6 +75,17 @@ class BottomActionSheet : BottomSheetDialogFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val type = arguments?.getString(ARG_TYPE)
+
+        // 리뷰일 때만 삭제 버튼 노출
+        if (type == TYPE_REVIEW) {
+            b.btnDelete.visibility = View.VISIBLE
+            b.btnEdit.visibility = View.GONE
+        } else {
+            b.btnDelete.visibility = View.GONE
+            b.btnEdit.visibility = View.GONE
+        }
+
         b.btnDelete.setOnClickListener {
             parentFragmentManager.setFragmentResult(
                 REQUEST_KEY,
@@ -76,31 +93,17 @@ class BottomActionSheet : BottomSheetDialogFragment() {
             )
             dismiss()
         }
-
-        b.btnEdit.setOnClickListener {
-            parentFragmentManager.setFragmentResult(
-                REQUEST_KEY,
-                Bundle().apply { putString(RESULT_ACTION, ACTION_EDIT) }
-            )
-            dismiss()
-        }
     }
 
-    /**
-     * Window를 edge-to-edge로
-     * (하지만 배경은 투명)
-     */
     override fun onStart() {
         super.onStart()
 
         dialog?.window?.apply {
             val white = "#FEFEFE".toColorInt()
 
-            // Window 자체는 투명
             setBackgroundDrawableResource(android.R.color.transparent)
             setDimAmount(0.3f)
 
-            // 네비게이션 바 색상
             @Suppress("DEPRECATION")
             navigationBarColor = white
 
@@ -108,7 +111,6 @@ class BottomActionSheet : BottomSheetDialogFragment() {
                 isAppearanceLightNavigationBars = true
             }
 
-            // 시스템 바 영역까지 확장
             setFlags(
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS

--- a/app/src/main/java/com/example/bisit/ui/shop/dialog/ConfirmDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/dialog/ConfirmDialog.kt
@@ -8,32 +8,33 @@ import com.example.bisit.databinding.DialogConfirmBinding
 
 class ConfirmDialog(
     private val message: String,
-    private val okText: String = "확인",
+    private val confirmText: String = "확인",
     private val cancelText: String = "닫기",
-    private val onOk: (() -> Unit)? = null
+    private val onConfirm: (() -> Unit)? = null
 ) : DialogFragment() {
 
-    private var _b: DialogConfirmBinding? = null
-    private val b get() = _b!!
+    private var _binding: DialogConfirmBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _b = DialogConfirmBinding.inflate(inflater, container, false)
-        return b.root
+        _binding = DialogConfirmBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        b.tvMessage.text = message
-        b.btnOk.text = okText
-        b.btnCancel.text = cancelText
 
-        b.btnCancel.setOnClickListener { dismiss() }
-        b.btnOk.setOnClickListener {
-            onOk?.invoke()
+        binding.tvMessage.text = message
+        binding.btnOk.text = confirmText
+        binding.btnCancel.text = cancelText
+
+        binding.btnCancel.setOnClickListener { dismiss() }
+        binding.btnOk.setOnClickListener {
+            onConfirm?.invoke()
             dismiss()
         }
     }
@@ -41,27 +42,25 @@ class ConfirmDialog(
     override fun onStart() {
         super.onStart()
         dialog?.window?.apply {
-            // 배경 투명하게
+            // 배경 투명
             setBackgroundDrawableResource(android.R.color.transparent)
 
-            // 화면 너비의 80.6%로 설정
+            // 화면 너비의 80.6%
             val screenWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 val wm = requireActivity().windowManager.currentWindowMetrics
                 val insets = wm.windowInsets.getInsets(WindowInsets.Type.systemBars())
                 wm.bounds.width() - insets.left - insets.right
             } else {
-                val displayMetrics = resources.displayMetrics
-                displayMetrics.widthPixels
+                resources.displayMetrics.widthPixels
             }
 
             val width = (screenWidth * 0.806f).toInt()
-            val height = ViewGroup.LayoutParams.WRAP_CONTENT
-            setLayout(width, height)
+            setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT)
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        _b = null
+        _binding = null
     }
 }

--- a/app/src/main/java/com/example/bisit/util/DateFormatter.kt
+++ b/app/src/main/java/com/example/bisit/util/DateFormatter.kt
@@ -1,0 +1,15 @@
+package com.example.bisit.util
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object DateFormatter {
+
+    private val reviewDateFormatter =
+        SimpleDateFormat("yyyy.MM.dd, E", Locale.KOREAN)
+
+    fun formatReviewVisitDate(date: Date): String {
+        return reviewDateFormatter.format(date)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,6 @@
     <string name="notice_content_count_default">0/50자</string>
     <string name="notice_submit">공지 등록하기</string>
 
-
+    <string name="review_visit_date">%1$s 방문</string>
 
 </resources>


### PR DESCRIPTION
## ✔️ 작업 내용

### 1. 매장 관리자 리뷰 목록 조회 기능 구현
- 매장 관리자 전용 리뷰 조회 API(`/api/reviews/shops/{shopId}/owner`) 연동
- 서버에서 내려주는 페이지네이션 구조(`ReviewPage`)에 맞춰 Repository / ViewModel / Adapter 구성
- 리뷰 삭제 후 즉시 리스트에 반영되는 optimistic update 적용

### 2. shopId 흐름 정리 및 ViewModel 역할 분리
- `ShopRegisterViewModel`에서 가게 등록 결과로 내려오는 `shopId`를 단일 소스로 관리
- `ShopReviewsViewModel`은 `setShopId()`를 통해 외부에서 주입받아 사용하는 소비자 역할로 명확히 분리
- Fragment가 shopId를 중계하는 구조로 ViewModel 간 직접 의존 제거

### 3. RecyclerView 안정성 개선
- DiffUtil 기준을 `createdAt` → **서버 식별자 `reviewId` 기준**으로 수정
- 리뷰 삭제/갱신 시 RecyclerView 깜빡임 및 오작동 방지
- Adapter에서 날짜 포맷 및 UI 바인딩 책임만 수행하도록 단순화

### 4. API 24 대응 날짜 처리 리팩토링
- `java.time(LocalDate, DateTimeFormatter)` 사용으로 인한 minSdk(24) 충돌 해결
- 날짜 타입을 String 기반으로 수신 후 `SimpleDateFormat` + 공용 유틸로 포맷 처리
- Adapter 내 직접 변환 로직 제거 → 재사용 가능한 구조로 개선

### 5. 공통 ConfirmDialog 개선
- 제목 없는 메시지 중심 다이얼로그로 단순화 (XML 구조에 맞게 재설계)
- Fragment 사용 방식에 맞춰 `message / onConfirm` 인터페이스로 통일
- 리뷰 삭제, 향후 다른 확인 액션에도 재사용 가능하도록 정리

## ⚠️ 어려웠던 점

### 1. shopId 전달 구조 정리
- 가게 등록 → 관리 화면 전환 과정에서 shopId의 책임 위치가 모호했음
- ViewModel이 직접 shopId를 생성하거나 보관하는 구조를 피하고,
  Fragment를 중계자로 두는 MVVM 정석 구조로 재정립

### 2. API 레벨 제약으로 인한 날짜 처리 이슈
- 서버 스펙은 LocalDate 형태였으나, 클라이언트 minSdk가 24라 `java.time` 사용 불가
- 단순한 Adapter 수정이 아닌, **모델 타입과 공용 유틸 설계까지 함께 수정 필요**

## 🔧 개선한 점

### 1. ViewModel 생성 방식 일관성 확보
- Repository를 생성자에서 요구하는 ViewModel은 Factory 사용
- `AndroidViewModel`은 기본 Factory를 활용해 불필요한 Factory 생성 제거
- ViewModel 생성 책임과 의존성 주입 방식이 명확해짐

### 2. UI 책임 최소화
- 로딩 시간이 짧은 리뷰 목록 화면에서 ProgressBar 제거
- 불필요한 로딩 UI 제거로 화면 단순화 및 UX 개선
- 데이터 변경에만 집중하는 구조로 Fragment 역할 정리

### 3. 코드 리뷰/확장에 유리한 구조
- 리뷰 / 사진 / 기본 정보 관리 화면이 동일한 패턴으로 확장 가능
- shopId 기반 관리 화면 전반에 재사용 가능한 구조 확보

## 📷 스크린샷
- 매장 관리자 리뷰 목록 화면
- 리뷰 삭제 BottomSheet 및 ConfirmDialog 노출 화면
- 리뷰 삭제 후 리스트 즉시 반영 화면

## 💬 참고 사항
- shopId는 `ShopRegisterViewModel`에서만 생성되며, 이후 관리 화면에서는 주입받아 사용합니다.
- 리뷰 삭제는 optimistic update 방식으로 처리되어 UX 지연 없이 즉시 반영됩니다.
- 날짜 포맷은 API 24 대응을 위해 공용 유틸로 분리되어 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 매장 리뷰 관리 기능 추가: 고객 리뷰 조회 및 삭제 가능
  * 리뷰 상세 정보 표시: 방문일, 평점, 고객명, 서비스명 등 통합 표시
  * 리뷰 삭제 시 확인 대화창 제공으로 실수 방지
  * 하단 액션 메뉴를 통한 직관적인 리뷰 관리 인터페이스

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->