### PR TITLE
[Fix/#96] 사장님 매장 관리&스태프 관리 UI 에러 수정

### DIFF
--- a/app/src/main/java/com/example/bisit/ui/shop/ShopFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopFragment.kt
@@ -28,7 +28,7 @@ class ShopFragment : Fragment() {
         ShopRegisterViewModelFactory(requireContext().applicationContext)
     }
 
-    /** 직원 신청 상태 ViewModel (Fragment scope) */
+    /** 직원 신청 상태 ViewModel (뱃지 표시용) */
     private lateinit var staffRequestViewModel: ShopStaffRequestViewModel
 
     override fun onCreateView(
@@ -43,7 +43,18 @@ class ShopFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        /** 직원 신청 ViewModel 초기화 */
+        setupStaffRequestViewModel()
+        setupViewPagerAndTabs()
+        setupStaffApplyNavigation()     // ⭐️ 무조건 이동
+        observeShopIdForBadgeOnly()     // ⭐️ 뱃지 표시만
+        observeStaffRequestState()
+
+        updateTabUI(0)
+    }
+
+    /* ===================== setup ===================== */
+
+    private fun setupStaffRequestViewModel() {
         val api = RetrofitClient.getStaffManageApi(requireContext())
         val repository = StaffManageRepository(api)
 
@@ -51,58 +62,10 @@ class ShopFragment : Fragment() {
             this,
             ShopStaffRequestViewModelFactory(repository)
         )[ShopStaffRequestViewModel::class.java]
-
-        /** shopId 관찰 (도착 시점에만 초기화) */
-        viewLifecycleOwner.lifecycleScope.launch {
-            shopRegisterViewModel.shopId.collect { shopId ->
-                if (shopId == null) return@collect
-
-                setupShopWithId(shopId)
-            }
-        }
-
-        /** 직원 신청 상태 관찰 → 아이콘 / 말풍선 반영 */
-        viewLifecycleOwner.lifecycleScope.launch {
-            staffRequestViewModel.state.collect { state ->
-                if (state.hasPendingRequest) {
-                    binding.ivStaffApply.setImageResource(
-                        R.drawable.ic_staff_new_apply
-                    )
-                    binding.ivStaffApplyBubble.visibility = View.VISIBLE
-                } else {
-                    binding.ivStaffApply.setImageResource(
-                        R.drawable.ic_staff_apply
-                    )
-                    binding.ivStaffApplyBubble.visibility = View.GONE
-                }
-            }
-        }
-
-        updateTabUI(0)
     }
 
-    /**
-     * shopId가 준비된 이후에만 호출되는 초기화 로직
-     */
-    private fun setupShopWithId(shopId: Long) {
-
-        /** Shop 진입 시 직원 신청 존재 여부 확인 */
-        staffRequestViewModel.checkPendingStaffExists(shopId)
-
-        /** 직원 신청 버튼 클릭 → StaffRequestsFragment 이동 */
-        binding.ivStaffApply.setOnClickListener {
-            val bundle = Bundle().apply {
-                putLong("shopId", shopId)
-            }
-            findNavController().navigate(
-                R.id.action_shopFragment_to_staffRequestsFragment,
-                bundle
-            )
-        }
-
-        /** ViewPager 설정 */
-        val pagerAdapter = ShopPagerAdapter(this, shopId)
-        binding.viewPager.adapter = pagerAdapter
+    private fun setupViewPagerAndTabs() {
+        binding.viewPager.adapter = ShopPagerAdapter(this)
 
         binding.tabBasic.setOnClickListener { binding.viewPager.currentItem = 0 }
         binding.tabReviews.setOnClickListener { binding.viewPager.currentItem = 1 }
@@ -118,10 +81,54 @@ class ShopFragment : Fragment() {
         )
     }
 
+    /**
+     * 직원 신청 페이지는 조건 없이 항상 이동 가능
+     */
+    private fun setupStaffApplyNavigation() {
+        binding.ivStaffApply.setOnClickListener {
+            findNavController().navigate(
+                R.id.action_shopFragment_to_staffManagementFragment
+            )
+        }
+    }
+
+    /* ===================== observe ===================== */
+
+    /**
+     * shopId는 '새 직원 신청 있음/없음' 뱃지 표시 용도
+     * 네비게이션 / 접근 제어와는 무관
+     */
+    private fun observeShopIdForBadgeOnly() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            shopRegisterViewModel.shopId.collect { shopId ->
+                if (shopId != null) {
+                    staffRequestViewModel.checkPendingStaffExists(shopId)
+                }
+                // shopId 없어도 아무것도 막지 않음
+            }
+        }
+    }
+
+    private fun observeStaffRequestState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            staffRequestViewModel.state.collect { state ->
+                if (state.hasPendingRequest) {
+                    binding.ivStaffApply.setImageResource(R.drawable.ic_staff_new_apply)
+                    binding.ivStaffApplyBubble.visibility = View.VISIBLE
+                } else {
+                    binding.ivStaffApply.setImageResource(R.drawable.ic_staff_apply)
+                    binding.ivStaffApplyBubble.visibility = View.GONE
+                }
+            }
+        }
+    }
+
+    /* ===================== UI ===================== */
+
     private fun updateTabUI(position: Int) {
-        val inactiveColor = "#9AA1AF".toColorInt()
-        val activeColor = "#6D7583".toColorInt()
-        val indicatorColor = "#4076FF".toColorInt()
+        val inactive = "#9AA1AF".toColorInt()
+        val active = "#6D7583".toColorInt()
+        val indicator = "#4076FF".toColorInt()
 
         listOf(
             binding.indicatorBasic,
@@ -135,24 +142,24 @@ class ShopFragment : Fragment() {
             binding.tvReviews,
             binding.tvServices,
             binding.tvNotices
-        ).forEach { it.setTextColor(inactiveColor) }
+        ).forEach { it.setTextColor(inactive) }
 
         when (position) {
             0 -> {
-                binding.indicatorBasic.setBackgroundColor(indicatorColor)
-                binding.tvBasic.setTextColor(activeColor)
+                binding.indicatorBasic.setBackgroundColor(indicator)
+                binding.tvBasic.setTextColor(active)
             }
             1 -> {
-                binding.indicatorReviews.setBackgroundColor(indicatorColor)
-                binding.tvReviews.setTextColor(activeColor)
+                binding.indicatorReviews.setBackgroundColor(indicator)
+                binding.tvReviews.setTextColor(active)
             }
             2 -> {
-                binding.indicatorServices.setBackgroundColor(indicatorColor)
-                binding.tvServices.setTextColor(activeColor)
+                binding.indicatorServices.setBackgroundColor(indicator)
+                binding.tvServices.setTextColor(active)
             }
             3 -> {
-                binding.indicatorNotices.setBackgroundColor(indicatorColor)
-                binding.tvNotices.setTextColor(activeColor)
+                binding.indicatorNotices.setBackgroundColor(indicator)
+                binding.tvNotices.setTextColor(active)
             }
         }
     }

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopPagerAdapter.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopPagerAdapter.kt
@@ -3,18 +3,18 @@ package com.example.bisit.ui.shop
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
-class ShopPagerAdapter(parent: Fragment, private val shopId: Long) : FragmentStateAdapter(parent) {
-    override fun getItemCount(): Int = 4
-    override fun createFragment(position: Int) = when (position) {
-        0 -> ShopBasicFragment()
-        1 -> {
-            val fragment = ShopReviewsFragment()
-            val bundle = android.os.Bundle()
-            bundle.putLong("shopId", shopId)
-            fragment.arguments = bundle
-            fragment
+class ShopPagerAdapter(
+    fragment: Fragment
+) : FragmentStateAdapter(fragment) {
+
+    override fun getItemCount() = 4
+
+    override fun createFragment(position: Int): Fragment =
+        when (position) {
+            0 -> ShopBasicFragment()
+            1 -> ShopReviewsFragment()
+            2 -> ShopServicesFragment()
+            3 -> ShopNoticesFragment()
+            else -> throw IllegalStateException()
         }
-        2 -> ShopServicesFragment()
-        else -> ShopNoticesFragment()
-    }
 }

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffListFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffListFragment.kt
@@ -14,6 +14,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.bisit.R
 import com.example.bisit.data.api.RetrofitClient
 import com.example.bisit.data.repository.staffManage.StaffManageRepository
+import com.example.bisit.ui.shop.ShopRegisterViewModel
+import com.example.bisit.ui.shop.ShopRegisterViewModelFactory
 import com.example.bisit.ui.staffManage.adapter.StaffListAdapter
 import com.example.bisit.ui.staffManage.modal.DeleteCompleteDialog
 import com.example.bisit.ui.staffManage.modal.DeleteStaffDialog
@@ -21,13 +23,18 @@ import kotlinx.coroutines.launch
 
 class StaffListFragment : Fragment() {
 
-    // StaffManage 전체에서 공유하는 ViewModel
+    // 직원 관리 ViewModel (기존 그대로)
     private val viewModel: StaffManageViewModel by activityViewModels {
         StaffManageViewModelFactory(
             StaffManageRepository(
                 RetrofitClient.getStaffManageApi(requireContext())
             )
         )
+    }
+
+    // shopId 단일 소스
+    private val shopRegisterViewModel: ShopRegisterViewModel by activityViewModels {
+        ShopRegisterViewModelFactory(requireContext().applicationContext)
     }
 
     private lateinit var adapter: StaffListAdapter
@@ -50,15 +57,20 @@ class StaffListFragment : Fragment() {
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
 
-        // 승인된 직원 목록
+        // 승인된 직원 목록 관찰
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.approvedStaffs.collect { list ->
                 adapter.submitList(list)
             }
         }
 
-        // 최초 로드
-        viewModel.loadApprovedStaffs(getShopId())
+        // shopId 도착 시점에만 API 호출
+        viewLifecycleOwner.lifecycleScope.launch {
+            shopRegisterViewModel.shopId.collect { shopId ->
+                shopId ?: return@collect
+                viewModel.loadApprovedStaffs(shopId)
+            }
+        }
 
         val sortToggle = view.findViewById<ImageView>(R.id.ivSortList)
         sortToggle.setOnClickListener {
@@ -71,23 +83,18 @@ class StaffListFragment : Fragment() {
     private fun showDeleteDialog(staffId: Long) {
         DeleteStaffDialog(
             onConfirm = {
-                // 직원 삭제 (리스트 즉시 반영)
-                viewModel.deleteStaff(getShopId(), staffId)
+                val shopId = shopRegisterViewModel.shopId.value ?: return@DeleteStaffDialog
 
-                // ️기존 삭제 확인 모달 닫기
+                viewModel.deleteStaff(shopId, staffId)
+
                 (parentFragmentManager.findFragmentByTag("delete_staff")
                         as? DeleteStaffDialog)?.dismiss()
 
-                // 삭제 완료 모달 표시
                 DeleteCompleteDialog().show(
                     parentFragmentManager,
                     "delete_complete"
                 )
             }
         ).show(parentFragmentManager, "delete_staff")
-    }
-
-    private fun getShopId(): Long {
-        return requireArguments().getLong("shopId")
     }
 }

--- a/app/src/main/java/com/example/bisit/ui/staffManage/StaffRequestsFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/staffManage/StaffRequestsFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -14,6 +15,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.bisit.R
 import com.example.bisit.data.api.RetrofitClient
 import com.example.bisit.data.repository.staffManage.StaffManageRepository
+import com.example.bisit.ui.shop.ShopRegisterViewModel
+import com.example.bisit.ui.shop.ShopRegisterViewModelFactory
 import com.example.bisit.ui.staffManage.adapter.StaffRequestAdapter
 import com.example.bisit.ui.staffManage.modal.StaffRequestResultDialog
 import kotlinx.coroutines.launch
@@ -23,15 +26,18 @@ class StaffRequestsFragment : Fragment() {
     private lateinit var viewModel: StaffManageViewModel
     private lateinit var adapter: StaffRequestAdapter
 
+    // ⭐️ shopId 단일 소스
+    private val shopRegisterViewModel: ShopRegisterViewModel by activityViewModels {
+        ShopRegisterViewModelFactory(requireContext().applicationContext)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-
         val view = inflater.inflate(R.layout.fragment_staff_requests, container, false)
 
-        // API / Repository / ViewModel
         val api = RetrofitClient.getStaffManageApi(requireContext())
         val repository = StaffManageRepository(api)
 
@@ -40,34 +46,40 @@ class StaffRequestsFragment : Fragment() {
             StaffManageViewModelFactory(repository)
         )[StaffManageViewModel::class.java]
 
-        // RecyclerView
         val recyclerView = view.findViewById<RecyclerView>(R.id.rvStaffRequests)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
 
         adapter = StaffRequestAdapter(
             onApprove = { staffId ->
-                viewModel.approveStaff(getShopId(), staffId)
-                showResultDialog("직원 요청이 승인되었습니다.")
+                shopRegisterViewModel.shopId.value?.let { shopId ->
+                    viewModel.approveStaff(shopId, staffId)
+                    showResultDialog("직원 요청이 승인되었습니다.")
+                }
             },
             onReject = { staffId ->
-                viewModel.rejectStaff(getShopId(), staffId)
-                showResultDialog("직원 요청이 거절되었습니다.")
+                shopRegisterViewModel.shopId.value?.let { shopId ->
+                    viewModel.rejectStaff(shopId, staffId)
+                    showResultDialog("직원 요청이 거절되었습니다.")
+                }
             }
         )
         recyclerView.adapter = adapter
 
-        // 직원 신청 목록 최초 로드
-        viewModel.loadPendingStaffs(getShopId())
+        // shopId 관찰해서 최초 로드
+        viewLifecycleOwner.lifecycleScope.launch {
+            shopRegisterViewModel.shopId.collect { shopId ->
+                shopId ?: return@collect
+                viewModel.loadPendingStaffs(shopId)
+            }
+        }
 
-        // 목록 관찰
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.pendingStaffs.collect { list ->
                 adapter.submitList(list)
             }
         }
 
-        val sortToggle = view.findViewById<ImageView>(R.id.ivSortRequest)
-        sortToggle.setOnClickListener {
+        view.findViewById<ImageView>(R.id.ivSortRequest).setOnClickListener {
             Toast.makeText(requireContext(), "정렬 기준 변경", Toast.LENGTH_SHORT).show()
         }
 
@@ -77,9 +89,5 @@ class StaffRequestsFragment : Fragment() {
     private fun showResultDialog(message: String) {
         StaffRequestResultDialog(message)
             .show(parentFragmentManager, "staff_request_result")
-    }
-
-    private fun getShopId(): Long {
-        return requireArguments().getLong("shopId")
     }
 }

--- a/app/src/main/res/layout/fragment_staff_management.xml
+++ b/app/src/main/res/layout/fragment_staff_management.xml
@@ -11,7 +11,7 @@
         android:layout_height="56dp"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="39dp"
         android:paddingHorizontal="18dp"
         tools:ignore="UseCompoundDrawables">
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -119,10 +119,9 @@
         tools:layout="@layout/fragment_shop">
 
         <action
-            android:id="@+id/action_shopFragment_to_staffRequestsFragment"
-            app:destination="@id/staffRequestsFragment" />
+            android:id="@+id/action_shopFragment_to_staffManagementFragment"
+            app:destination="@id/staffManagementFragment" />
     </fragment>
-
 
     <fragment
         android:id="@+id/customerShopFragment"
@@ -337,15 +336,9 @@
         tools:layout="@layout/fragment_customer_pay_coupon"/>
 
     <fragment
-        android:id="@+id/staffRequestsFragment"
-        android:name="com.example.bisit.ui.staffManage.StaffRequestsFragment"
-        android:label="fragment_staff_requests"
-        tools:layout="@layout/fragment_staff_requests">
-
-        <argument
-            android:name="shopId"
-            app:argType="long" />
-    </fragment>
-
+        android:id="@+id/staffManagementFragment"
+        android:name="com.example.bisit.ui.staffManage.StaffManagementFragment"
+        android:label="fragment_staff_management"
+        tools:layout="@layout/fragment_staff_management" />
 
 </navigation>


### PR DESCRIPTION
## ✔️ 작업 내용
- 직원 관리 아이콘 클릭 시 발생하던 앱 크래시 원인 분석 및 수정
- `StaffManagementFragment` 진입 구조를 Navigation arguments 의존 없이 동작하도록 리팩토링
- `ViewPager2 + FragmentStateAdapter` 내부 Fragment(`StaffRequestsFragment`, `StaffListFragment`)의 잘못된 `requireArguments()` 사용 제거
- `shopId` 전달 방식을 Navigation arguments → **Activity scope ViewModel 단일 소스** 구조로 변경
- 직원 신청 여부와 관계없이 직원 관리 화면에 항상 진입 가능하도록 UX 흐름 개선
- 직원 신청 알림(아이콘/말풍선) 로직과 직원 관리 화면 진입 로직을 명확히 분리

## 🧠 어려웠던 점
- 크래시가 **화면 전환 직후가 아니라 ViewPager 스크롤 시점**에 발생하여 원인 파악이 쉽지 않았음
- 로그상 `StaffListFragment does not have any arguments` 에러가 발생했지만,  
  실제로는 Navigation 문제가 아니라 **Fragment 생성 방식(ViewPager)** 과 arguments 설계의 불일치가 원인이었음
- 직원 관리 관련 Fragment들이 서로 다른 방식(Activity scope / Fragment scope ViewModel, arguments)을 혼합 사용하고 있어
  책임 경계를 다시 정리해야 했음

## 🔧 개선한 점
- `shopId`를 Navigation arguments에 의존하지 않고 **Activity 범위 ViewModel에서 일관되게 관리**
- ViewPager 내부 Fragment는 **arguments 없는 상태에서도 안전하게 생성 가능**하도록 구조 정리
- 직원 신청 여부 체크(알림 표시)와 실제 직원 관리 화면 진입을 분리하여 역할을 명확히 함
- 동일한 크래시가 재발하지 않도록 `requireArguments()` 사용 위치를 전면 점검

## 📷 스크린샷
- 직원 관리 아이콘 클릭 → StaffManagement 화면 정상 진입
- 직원 요청 / 직원 목록 탭 전환 시 크래시 없이 ViewPager 정상 동작
- 신규 직원 신청 존재 여부에 따른 아이콘/말풍선 UI 정상 반영

## 💬 참고 사항
- ViewPager2 내부 Fragment에서는 Navigation arguments 사용을 지양하는 것이 안전합니다.
- 공통 식별자(`shopId`)는 Navigation보다 **Activity scope ViewModel 단일 소스**로 관리하는 구조가 유지보수에 유리합니다.
- 동일 패턴의 Fragment 추가 시에도 해당 구조를 그대로 확장 가능하도록 설계되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 직원 관리 네비게이션 흐름이 개선되었습니다.

* **버그 수정**
  * 직원 데이터 관리 시스템이 중앙 집중식으로 통합되어 안정성이 향상되었습니다.

* **UI/UX**
  * 직원 관리 화면의 헤더 여백이 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->