### PR TITLE
[Fix] 사장님 매장관리 - 영업시간 추가

### DIFF
--- a/app/src/main/res/layout/fragment_shop_basic.xml
+++ b/app/src/main/res/layout/fragment_shop_basic.xml
@@ -6,287 +6,392 @@
     android:layout_height="match_parent"
     android:background="#F0F2F5">
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent">
 
-        <!-- 상단 이미지 -->
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="181dp">
-
-            <ImageView
-                android:id="@+id/imgHeader"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:scaleType="centerCrop"
-                android:src="@drawable/sample_header" />
-
-            <TextView
-                android:id="@+id/btnChangeHeader"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="end|top"
-                android:layout_margin="12dp"
-                android:paddingHorizontal="14dp"
-                android:paddingVertical="10dp"
-                android:text="대표 이미지 변경하기"
-                android:textColor="#515965"
-                android:background="@drawable/bg_chip_selector" />
-        </FrameLayout>
-
-        <!-- 매장 정보 카드 -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:background="@drawable/bg_card_top_rounded"
-            android:paddingHorizontal="18dp"
-            android:paddingTop="24dp"
-            android:paddingBottom="28dp"
-            android:layout_marginTop="-24dp">
+            android:orientation="vertical">
 
+            <!-- 상단 이미지 -->
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="181dp">
+
+                <ImageView
+                    android:id="@+id/imgHeader"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/sample_header" />
+
+                <TextView
+                    android:id="@+id/btnChangeHeader"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end|top"
+                    android:layout_margin="12dp"
+                    android:paddingHorizontal="14dp"
+                    android:paddingVertical="10dp"
+                    android:text="대표 이미지 변경하기"
+                    android:textColor="#515965"
+                    android:background="@drawable/bg_chip_selector" />
+            </FrameLayout>
+
+            <!-- 매장 정보 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
+                android:orientation="vertical"
+                android:background="@drawable/bg_card_top_rounded"
+                android:paddingHorizontal="18dp"
+                android:paddingTop="24dp"
+                android:paddingBottom="28dp"
+                android:layout_marginTop="-24dp">
 
-                <TextView
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="매장 정보"
-                    android:textSize="16sp"
-                    android:textColor="#222222" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
 
-                <Space
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_weight="1" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="매장 정보"
+                        android:textSize="16sp"
+                        android:textColor="#222222" />
 
-                <TextView
-                    android:id="@+id/btnEditShopInfo"
-                    android:layout_width="wrap_content"
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:layout_weight="1" />
+
+                    <TextView
+                        android:id="@+id/btnEditShopInfo"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:padding="8dp"
+                        android:text="@string/underlined_text"
+                        android:textSize="13sp"
+                        android:textColor="#515965" />
+                </LinearLayout>
+
+                <!-- 이름 -->
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="8dp"
-                    android:text="@string/underlined_text"
-                    android:textSize="13sp"
-                    android:textColor="#515965" />
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_shop_grey"
+                        android:layout_marginEnd="6dp" />
+
+                    <TextView
+                        android:id="@+id/tvShopName"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="장미헤어"
+                        android:textSize="14sp"
+                        android:textColor="#222222" />
+                </LinearLayout>
+
+                <!-- 전화 -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_phone"
+                        android:layout_marginEnd="6dp" />
+
+                    <TextView
+                        android:id="@+id/tvShopPhone"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="010-0000-0000"
+                        android:textSize="14sp"
+                        android:textColor="#222222" />
+                </LinearLayout>
+
+                <!-- 주소 -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_location"
+                        android:layout_marginEnd="6dp" />
+
+                    <TextView
+                        android:id="@+id/tvShopAddress"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="대구 중구 관덕정길 6-11 1층"
+                        android:textSize="14sp"
+                        android:textColor="#222222" />
+                </LinearLayout>
             </LinearLayout>
 
-            <!-- 가게 이름 -->
+            <!-- 매장 소개 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-                <ImageView
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:src="@drawable/ic_shop_grey"
-                    android:layout_marginEnd="6dp" />
-                <TextView
-                    android:id="@+id/tvShopName"
-                    android:layout_width="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/bg_card_noradius"
+                android:paddingHorizontal="18dp"
+                android:paddingTop="24dp"
+                android:paddingBottom="28dp"
+                android:layout_marginTop="6dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="장미헤어"
-                    android:textColor="#222222"
-                    android:textSize="14sp" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="매장 소개"
+                        android:textSize="16sp"
+                        android:textColor="#222222" />
+
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:layout_weight="1" />
+
+                    <TextView
+                        android:id="@+id/btnEditIntro"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:padding="8dp"
+                        android:text="@string/underlined_text"
+                        android:textSize="13sp"
+                        android:textColor="#515965" />
+                </LinearLayout>
+
+                <!-- 소개 내용 -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_info"
+                        android:layout_marginEnd="6dp" />
+                    <TextView
+                        android:id="@+id/tvShopIntro"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="10년차 아티스트가 운영하는 장미헤어입니다."
+                        android:textColor="#222222"
+                        android:textSize="14sp" />
+                </LinearLayout>
+
+                <!-- 방문 서비스 -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_service"
+                        android:layout_marginEnd="6dp" />
+                    <TextView
+                        android:id="@+id/tvShopService"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="방문 서비스"
+                        android:textColor="#222222"
+                        android:textSize="14sp" />
+                </LinearLayout>
             </LinearLayout>
 
-            <!-- 전화번호 -->
+            <!-- 매출 관리 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-                <ImageView
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:src="@drawable/ic_phone"
-                    android:layout_marginEnd="6dp" />
-                <TextView
-                    android:id="@+id/tvShopPhone"
-                    android:layout_width="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/bg_card_noradius"
+                android:paddingHorizontal="18dp"
+                android:paddingTop="24dp"
+                android:paddingBottom="28dp"
+                android:layout_marginTop="6dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="010-0000-0000"
-                    android:textColor="#222222"
-                    android:textSize="14sp" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="매출 관리"
+                        android:textSize="16sp"
+                        android:textColor="#222222" />
+
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:layout_weight="1" />
+
+                    <TextView
+                        android:id="@+id/btnEditSales"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:padding="8dp"
+                        android:text="@string/underlined_text"
+                        android:textSize="13sp"
+                        android:textColor="#515965" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_account"
+                        android:layout_marginEnd="6dp" />
+
+                    <TextView
+                        android:id="@+id/tvSalesAccount"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="국민 638120024166291 정원렬"
+                        android:textColor="#666666"
+                        android:textSize="14sp" />
+                </LinearLayout>
             </LinearLayout>
 
-            <!-- 주소 -->
+            <!-- 영업 시간 관리 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-                <ImageView
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:src="@drawable/ic_location"
-                    android:layout_marginEnd="6dp" />
-                <TextView
-                    android:id="@+id/tvShopAddress"
-                    android:layout_width="wrap_content"
+                android:layout_marginTop="6dp"
+                android:orientation="vertical"
+                android:background="@drawable/bg_card_noradius"
+                android:paddingHorizontal="18dp"
+                android:paddingTop="24dp"
+                android:paddingBottom="60dp">
+
+                <!-- 타이틀 + 수정하기 -->
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="대구 중구 관덕정길 6-11 1층"
-                    android:textColor="#222222"
-                    android:textSize="14sp" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="영업 시간"
+                        android:textSize="16sp"
+                        android:textColor="#222222" />
+
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:layout_weight="1" />
+
+                    <TextView
+                        android:id="@+id/btnEditOpenHour"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:padding="8dp"
+                        android:text="@string/underlined_text"
+                        android:textSize="13sp"
+                        android:textColor="#515965" />
+                </LinearLayout>
+
+                <!-- 영업중 + 펼치기 -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_customer_clock"
+                        android:layout_marginEnd="6dp" />
+
+                    <TextView
+                        android:id="@+id/tvOpenInfo"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="영업중 09:00 ~ 18:00"
+                        android:textSize="14sp"
+                        android:textColor="#222222" />
+
+                    <ImageView
+                        android:id="@+id/btnExpandHour"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginStart="4dp"
+                        android:src="@drawable/ic_down_arrow" />
+                </LinearLayout>
+
+                <!-- 영업시간 상세 -->
+                <LinearLayout
+                    android:id="@+id/layoutOpenHourDetail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginStart="30dp"
+                    android:orientation="vertical"
+                    android:visibility="gone">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="월 09:00 ~ 18:00"
+                        android:textSize="13sp"
+                        android:textColor="#222222" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="일 휴무"
+                        android:textSize="13sp"
+                        android:textColor="#222222"
+                        android:layout_marginTop="2dp" />
+                </LinearLayout>
             </LinearLayout>
         </LinearLayout>
-
-        <!-- 매장 소개 -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:background="@drawable/bg_card_noradius"
-            android:paddingHorizontal="18dp"
-            android:paddingTop="24dp"
-            android:paddingBottom="28dp"
-            android:layout_marginTop="6dp">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="매장 소개"
-                    android:textSize="16sp"
-                    android:textColor="#222222" />
-
-                <Space
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_weight="1" />
-
-                <TextView
-                    android:id="@+id/btnEditIntro"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="8dp"
-                    android:text="@string/underlined_text"
-                    android:textSize="13sp"
-                    android:textColor="#515965" />
-            </LinearLayout>
-
-            <!-- 소개 내용 -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-                <ImageView
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:src="@drawable/ic_info"
-                    android:layout_marginEnd="6dp" />
-                <TextView
-                    android:id="@+id/tvShopIntro"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="10년차 아티스트가 운영하는 장미헤어입니다."
-                    android:textColor="#222222"
-                    android:textSize="14sp" />
-            </LinearLayout>
-
-            <!-- 방문 서비스 -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-                <ImageView
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:src="@drawable/ic_service"
-                    android:layout_marginEnd="6dp" />
-                <TextView
-                    android:id="@+id/tvShopService"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="방문 서비스"
-                    android:textColor="#222222"
-                    android:textSize="14sp" />
-            </LinearLayout>
-        </LinearLayout>
-
-        <!-- 매출 관리 -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:background="@drawable/bg_card_noradius"
-            android:paddingHorizontal="18dp"
-            android:paddingTop="24dp"
-            android:layout_marginTop="6dp">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="매출 관리"
-                    android:textSize="16sp"
-                    android:textColor="#222222" />
-
-                <Space
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_weight="1" />
-
-                <TextView
-                    android:id="@+id/btnEditSales"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="8dp"
-                    android:text="@string/underlined_text"
-                    android:textSize="13sp"
-                    android:textColor="#515965" />
-            </LinearLayout>
-
-            <!-- 계좌 -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-                <ImageView
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:src="@drawable/ic_account"
-                    android:layout_marginEnd="6dp" />
-                <TextView
-                    android:id="@+id/tvSalesAccount"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="국민 638120024166291 정원렬"
-                    android:textColor="#666666"
-                    android:textSize="14sp" />
-            </LinearLayout>
-        </LinearLayout>
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:background="#FEFEFE" />
-    </LinearLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## ✔️ 작업 내용
- 매장 관리 화면에 **영업 시간 관리 섹션** 추가
- 영업중 상태 및 시간 표시 + **펼치기(토글)** 기능 구현
- 영업 시간 섹션 상단에 **수정하기 버튼** 추가하여 다른 카드들과 UI 패턴 통일
- 하단 탭으로 인한 가림 현상을 방지하기 위해  
  영업 시간 카드 내부에 **하단 padding 적용**
- ScrollView 구조에서 하단 영역이 잘리는 문제 해결

## 📷 스크린샷
- 영업 시간 관리 섹션 추가 화면
- 영업 시간 펼침/접힘 상태 화면

## 💬 참고 사항
- 기존 매출 관리, 매장 소개 카드 구조는 변경하지 않았습니다.
- 하단 여백은 하단 탭 높이를 고려해 paddingBottom으로 처리했습니다.
- 이후 영업 시간 수정 화면 연결 시 `btnEditOpenHour` 클릭 이벤트만 추가하면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 영업 시간 관리 기능 개선 - 확장 가능한 시간 상세 정보 뷰 추가
  * 매장 정보 카드 레이아웃 통합으로 정보 접근성 향상

* **개선사항**
  * 스크롤 가능한 레이아웃으로 전체 화면 탐색 개선
  * 매장 정보, 매출 관리 섹션 시각적 계층 재구성
  * 전화번호, 주소, 매장 소개 정보 표시 방식 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->