### PR TITLE
[Feature/#133] 전역 global-overlay 설정 및 온보딩 세팅

### DIFF
--- a/app/src/main/java/com/example/bisit/MainActivity.kt
+++ b/app/src/main/java/com/example/bisit/MainActivity.kt
@@ -1,30 +1,66 @@
 package com.example.bisit
 
+import android.content.Context
+import android.graphics.Rect
+import android.graphics.RectF
 import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowInsetsController
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.WindowCompat
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.findNavController
 import androidx.navigation.ui.NavigationUI
 import com.example.bisit.databinding.ActivityMainBinding
+import com.example.bisit.ui.shop.HighlightOverlayView
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
+
+    private var isOwner: Boolean = false
+    private var onboardingEnabled: Boolean = false
+
+    /* ===================== 온보딩 단계 ===================== */
+
+    enum class GuideStep {
+        TAB,
+        EDIT_BUTTON,
+        SERVICE_TAB,
+        SERVICE_SCREEN,
+        TODAY_TAB,
+        TODAY_SCREEN,
+        MY_TAB,
+        DONE
+    }
+
+    var currentGuideStep: GuideStep = GuideStep.DONE
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // 상태바 흰색 배경, 아이콘 어둡게 설정
         setupStatusBar()
 
         val userType = intent.getStringExtra("USER_TYPE")
+        isOwner = userType == "owner"
 
+        setupBottomNav(userType)
+        setupNavGraph(userType)
+
+        setupGuideTouch()
+        setupSkipListener()
+
+        if (isOwner && !isOnboardingCompleted()) {
+            onboardingEnabled = true
+            currentGuideStep = GuideStep.TAB
+        }
+    }
+
+    /* ===================== 네비 설정 ===================== */
+
+    private fun setupBottomNav(userType: String?) {
         binding.bottomNavView.menu.clear()
 
         if (userType == "owner") {
@@ -32,11 +68,14 @@ class MainActivity : AppCompatActivity() {
         } else {
             binding.bottomNavView.inflateMenu(R.menu.bottom_nav_menu)
         }
+    }
 
-        val navHostFragment = supportFragmentManager
-            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+    private fun setupNavGraph(userType: String?) {
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.nav_host_fragment)
+                    as NavHostFragment
+
         val navController = navHostFragment.navController
-
         val navGraph = navController.navInflater.inflate(R.navigation.nav_graph)
 
         if (userType == "owner") {
@@ -49,48 +88,152 @@ class MainActivity : AppCompatActivity() {
         NavigationUI.setupWithNavController(binding.bottomNavView, navController)
     }
 
+    /* ===================== 오버레이 터치 = 다음 단계 ===================== */
+
+    private fun setupGuideTouch() {
+        binding.globalOverlay.setOnClickListener {
+            if (!onboardingEnabled) return@setOnClickListener
+            goToNextStep()
+        }
+    }
+
+    /* ===================== Skip 버튼 (Overlay 내부 버튼 사용) ===================== */
+
+    private fun setupSkipListener() {
+        binding.globalOverlay.setOnSkipClickListener {
+            finishOnboarding()
+            binding.bottomNavView.selectedItemId = R.id.shopFragment
+        }
+    }
+
+    /* ===================== 단계 전환 ===================== */
+
+    private fun goToNextStep() {
+
+        when (currentGuideStep) {
+
+            GuideStep.TAB -> {
+                currentGuideStep = GuideStep.EDIT_BUTTON
+            }
+
+            GuideStep.EDIT_BUTTON -> {
+                currentGuideStep = GuideStep.SERVICE_TAB
+            }
+
+            GuideStep.SERVICE_TAB -> {
+                currentGuideStep = GuideStep.SERVICE_SCREEN
+            }
+
+            GuideStep.SERVICE_SCREEN -> {
+                currentGuideStep = GuideStep.TODAY_TAB
+                binding.bottomNavView.selectedItemId = R.id.todayReservFragment
+            }
+
+            GuideStep.TODAY_TAB -> {
+                currentGuideStep = GuideStep.TODAY_SCREEN
+            }
+
+            GuideStep.TODAY_SCREEN -> {
+                currentGuideStep = GuideStep.MY_TAB
+                binding.bottomNavView.selectedItemId = R.id.myPageOwnerFragment
+            }
+
+            GuideStep.MY_TAB -> {
+                finishOnboarding()
+            }
+
+            else -> finishOnboarding()
+        }
+    }
+
+    /* ===================== 글로벌 오버레이 ===================== */
+
+    fun showGlobalOverlay(
+        targetView: View,
+        guideText: String,
+        shape: HighlightOverlayView.HighlightShape =
+            HighlightOverlayView.HighlightShape.ROUNDED_RECT,
+        radiusDp: Float = 12f
+    ) {
+        if (!onboardingEnabled) return
+
+        val rect = Rect()
+        targetView.getGlobalVisibleRect(rect)
+
+        val rectF = RectF(rect)
+
+        binding.globalOverlay.visibility = View.VISIBLE
+        binding.globalGuideText.visibility = View.VISIBLE
+
+        binding.globalOverlay.highlight(
+            rect = rectF,
+            shape = shape,
+            radiusDp = radiusDp
+        )
+
+        binding.globalGuideText.text = guideText
+        binding.globalGuideText.x = rect.left.toFloat()
+        binding.globalGuideText.y = rect.bottom + 24f
+    }
+
+    fun hideGlobalOverlay() {
+        binding.globalOverlay.visibility = View.GONE
+        binding.globalGuideText.visibility = View.GONE
+    }
+
+    /* ===================== 온보딩 완료 ===================== */
+
+    fun finishOnboarding() {
+        currentGuideStep = GuideStep.DONE
+        onboardingEnabled = false
+        saveOnboardingCompleted()
+        hideGlobalOverlay()
+    }
+
+    private fun isOnboardingCompleted(): Boolean {
+        val prefs = getSharedPreferences("guide_pref", Context.MODE_PRIVATE)
+        return prefs.getBoolean("owner_onboarding_done", false)
+    }
+
+    private fun saveOnboardingCompleted() {
+        val prefs = getSharedPreferences("guide_pref", Context.MODE_PRIVATE)
+        prefs.edit().putBoolean("owner_onboarding_done", true).apply()
+    }
+
+    /* ===================== 상태바 ===================== */
+
     private fun setupStatusBar() {
-        // 상태바 배경 흰색
         window.statusBarColor = android.graphics.Color.WHITE
-        
-        // 상태바 아이콘 어둡게 (어두운 아이콘 = light status bar)
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            // Android 11 (API 30) 이상
             window.insetsController?.setSystemBarsAppearance(
                 WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
                 WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
             )
         } else {
-            // Android 6.0 (API 23) ~ Android 10 (API 29)
             @Suppress("DEPRECATION")
-            window.decorView.systemUiVisibility = 
+            window.decorView.systemUiVisibility =
                 View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
         }
     }
 
+    /* ===================== 로그인 이동 ===================== */
+
     fun logout() {
         binding.bottomNavView.visibility = View.GONE
-
         val navController = findNavController(R.id.nav_host_fragment)
         val navGraph = navController.navInflater.inflate(R.navigation.nav_graph)
-
         navGraph.setStartDestination(R.id.authFragment)
-
         navController.setGraph(navGraph, null)
     }
 
     fun moveToHomeAfterLogin(userType: String) {
         binding.bottomNavView.visibility = View.VISIBLE
+        setupNavGraph(userType)
 
-        val navController = findNavController(R.id.nav_host_fragment)
-        val navGraph = navController.navInflater.inflate(R.navigation.nav_graph)
-
-        if (userType == "owner") {
-            navGraph.setStartDestination(R.id.shopFragment)
-        } else {
-            navGraph.setStartDestination(R.id.customerCategoryFragment)
+        if (userType == "owner" && !isOnboardingCompleted()) {
+            onboardingEnabled = true
+            currentGuideStep = GuideStep.TAB
         }
-
-        navController.setGraph(navGraph, null)
     }
 }

--- a/app/src/main/java/com/example/bisit/ui/shop/HighlightOverlayView.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/HighlightOverlayView.kt
@@ -1,0 +1,113 @@
+package com.example.bisit.ui.shop
+
+import android.content.Context
+import android.graphics.*
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.core.graphics.toColorInt
+import com.example.bisit.R
+
+class HighlightOverlayView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : FrameLayout(context, attrs) {
+
+    enum class HighlightShape {
+        RECT,
+        ROUNDED_RECT,
+        CIRCLE
+    }
+
+    private val dimPaint = Paint().apply {
+        color = "#CC222222".toColorInt() // 80% opacity
+    }
+
+    private val clearPaint = Paint().apply {
+        isAntiAlias = true
+        xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
+    }
+
+    private var highlightRect: RectF? = null
+    private var highlightShape: HighlightShape = HighlightShape.ROUNDED_RECT
+    private var cornerRadius: Float = 0f
+
+    private var skipClickListener: (() -> Unit)? = null
+
+    init {
+        setWillNotDraw(false)
+        LayoutInflater.from(context).inflate(R.layout.view_overlay_skip, this, true)
+
+        findViewById<TextView>(R.id.btnSkip).setOnClickListener {
+            skipClickListener?.invoke()
+        }
+    }
+
+    fun setOnSkipClickListener(listener: () -> Unit) {
+        skipClickListener = listener
+    }
+
+    fun highlight(
+        rect: RectF,
+        shape: HighlightShape = HighlightShape.ROUNDED_RECT,
+        radiusDp: Float = 0f
+    ) {
+        highlightRect = rect
+        highlightShape = shape
+        cornerRadius = dpToPx(radiusDp)
+        invalidate()
+    }
+
+    fun clearHighlight() {
+        highlightRect = null
+        invalidate()
+    }
+
+    override fun dispatchDraw(canvas: Canvas) {
+        val save = canvas.saveLayer(
+            0f,
+            0f,
+            width.toFloat(),
+            height.toFloat(),
+            null
+        )
+
+        // 1 전체 어둡게
+        canvas.drawRect(
+            0f,
+            0f,
+            width.toFloat(),
+            height.toFloat(),
+            dimPaint
+        )
+
+        // 2 강조 영역 투명 처리
+        highlightRect?.let { rect ->
+            when (highlightShape) {
+                HighlightShape.RECT -> {
+                    canvas.drawRect(rect, clearPaint)
+                }
+                HighlightShape.ROUNDED_RECT -> {
+                    canvas.drawRoundRect(
+                        rect,
+                        cornerRadius,
+                        cornerRadius,
+                        clearPaint
+                    )
+                }
+                HighlightShape.CIRCLE -> {
+                    canvas.drawOval(rect, clearPaint)
+                }
+            }
+        }
+
+        canvas.restoreToCount(save)
+
+        super.dispatchDraw(canvas)
+    }
+
+    private fun dpToPx(dp: Float): Float {
+        return dp * resources.displayMetrics.density
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopBasicFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopBasicFragment.kt
@@ -1,5 +1,7 @@
 package com.example.bisit.ui.shop
 
+import android.graphics.Rect
+import android.graphics.RectF
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -28,8 +30,6 @@ class ShopBasicFragment : Fragment() {
     private var _binding: FragmentShopBasicBinding? = null
     private val binding get() = _binding!!
 
-    /* ===================== ViewModel ===================== */
-
     private val shopRegisterViewModel: ShopRegisterViewModel by activityViewModels {
         ShopRegisterViewModelFactory(requireContext())
     }
@@ -37,11 +37,12 @@ class ShopBasicFragment : Fragment() {
     private val viewModel: ShopBasicViewModel by viewModels()
     private val photoViewModel: ShopPhotoViewModel by viewModels()
 
-    /* ===================== 화면 상태 ===================== */
-
     private var currentIntro: String = ""
     private var currentServiceType: String = "VISIT"
     private var isOpenHourExpanded = false
+
+    /* ===================== 온보딩 상태 ===================== */
+    private var guideStep = 0
 
     /* ===================== 이미지 선택 ===================== */
 
@@ -67,6 +68,82 @@ class ShopBasicFragment : Fragment() {
         observeViewModel()
         observePhotos()
         setupClickListeners()
+
+        // 온보딩 시작
+        startBasicGuide()
+    }
+
+    /* ===================== 온보딩 ===================== */
+
+    private fun startBasicGuide() {
+        binding.highlightOverlay.visibility = View.VISIBLE
+        showGuideStep()
+    }
+
+    private fun showGuideStep() {
+
+        val targets = listOf(
+            binding.btnEditShopInfo,
+            binding.btnEditIntro,
+            binding.btnEditSales
+        )
+
+        if (guideStep >= targets.size) {
+            endBasicGuide()
+            return
+        }
+
+        val target = targets[guideStep]
+
+        target.post {
+
+            val rect = Rect()
+            target.getGlobalVisibleRect(rect)
+
+            val overlayLoc = IntArray(2)
+            binding.highlightOverlay.getLocationOnScreen(overlayLoc)
+
+            val rectF = RectF(
+                rect.left - overlayLoc[0].toFloat(),
+                rect.top - overlayLoc[1].toFloat(),
+                rect.right - overlayLoc[0].toFloat(),
+                rect.bottom - overlayLoc[1].toFloat()
+            )
+
+            binding.highlightOverlay.highlight(
+                rectF,
+                HighlightOverlayView.HighlightShape.CIRCLE
+            )
+
+            if (guideStep == 0) {
+                binding.guideText.visibility = View.VISIBLE
+                binding.guideText.text =
+                    "매장 정보는\n이곳에서 수정할 수 있어요"
+
+                binding.guideText.post {
+                    binding.guideText.x =
+                        rectF.left - binding.guideText.width - 24f
+                    binding.guideText.y =
+                        rectF.centerY() - binding.guideText.height / 2f
+
+                    if (binding.guideText.x < 0) {
+                        binding.guideText.x = rectF.right + 24f
+                    }
+                }
+            } else {
+                binding.guideText.visibility = View.GONE
+            }
+        }
+
+        binding.highlightOverlay.setOnClickListener {
+            guideStep++
+            showGuideStep()
+        }
+    }
+
+    private fun endBasicGuide() {
+        binding.highlightOverlay.visibility = View.GONE
+        binding.guideText.visibility = View.GONE
     }
 
     /* ===================== shopId Observe ===================== */
@@ -82,7 +159,6 @@ class ShopBasicFragment : Fragment() {
                 viewModel.fetchShopDetail()
                 viewModel.fetchShopIntro()
                 viewModel.fetchShopAccount()
-
                 photoViewModel.fetchPhotos()
             }
         }
@@ -92,7 +168,6 @@ class ShopBasicFragment : Fragment() {
 
     private fun observeViewModel() {
 
-        // 매장 상세
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.shopDetail.collect { detail ->
                 detail ?: return@collect
@@ -103,7 +178,6 @@ class ShopBasicFragment : Fragment() {
             }
         }
 
-        // 매장 소개
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.shopIntro.collect { intro ->
                 intro ?: return@collect
@@ -113,11 +187,11 @@ class ShopBasicFragment : Fragment() {
 
                 binding.tvShopIntro.text = intro.intro
                 binding.tvShopService.text =
-                    if (intro.serviceChannel == "VISIT") "방문 서비스" else "매장 서비스"
+                    if (intro.serviceChannel == "VISIT") "방문 서비스"
+                    else "매장 서비스"
             }
         }
 
-        // 정산 계좌
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.shopAccount.collect { account ->
                 account ?: return@collect
@@ -126,7 +200,6 @@ class ShopBasicFragment : Fragment() {
             }
         }
 
-        // 영업 시간
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.shopOpenHour.collect { openHour ->
                 openHour ?: return@collect
@@ -175,7 +248,6 @@ class ShopBasicFragment : Fragment() {
 
     private fun setupClickListeners() {
 
-        // 매장 기본 정보 수정
         binding.btnEditShopInfo.setOnClickListener {
             EditShopInfoDialog(
                 initialName = binding.tvShopName.text.toString(),
@@ -192,11 +264,9 @@ class ShopBasicFragment : Fragment() {
             ).show(parentFragmentManager, "edit_shop_info")
         }
 
-        // 매장 소개 / 대표 이미지 변경
         binding.btnEditIntro.setOnClickListener { openIntroDialog() }
         binding.btnChangeHeader.setOnClickListener { openIntroDialog() }
 
-        // 정산 계좌 수정
         binding.btnEditSales.setOnClickListener {
             EditSalesDialog(
                 initialAccount = binding.tvSalesAccount.text.toString(),
@@ -210,10 +280,8 @@ class ShopBasicFragment : Fragment() {
             ).show(parentFragmentManager, "edit_sales")
         }
 
-        // 영업시간 펼치기
         binding.btnExpandHour.setOnClickListener {
             isOpenHourExpanded = !isOpenHourExpanded
-
             binding.layoutOpenHourDetail.visibility =
                 if (isOpenHourExpanded) View.VISIBLE else View.GONE
 
@@ -230,22 +298,13 @@ class ShopBasicFragment : Fragment() {
         }
     }
 
-    /* ===================== Intro Dialog ===================== */
-
     private fun openIntroDialog() {
         EditShopIntroDialog(
             initialIntro = currentIntro,
             initialServiceType = currentServiceType,
             photoFlow = photoViewModel.photos,
-
-            onAddPhotoClick = {
-                pickImageLauncher.launch("image/*")
-            },
-
-            onDeletePhotoClick = { photoId ->
-                photoViewModel.deletePhoto(photoId)
-            },
-
+            onAddPhotoClick = { pickImageLauncher.launch("image/*") },
+            onDeletePhotoClick = { photoId -> photoViewModel.deletePhoto(photoId) },
             onSaved = { intro, serviceType, photos ->
                 viewModel.updateShopIntro(
                     intro = intro,
@@ -255,8 +314,6 @@ class ShopBasicFragment : Fragment() {
             }
         ).show(parentFragmentManager, "edit_intro")
     }
-
-    /* ===================== Uri → Multipart ===================== */
 
     private fun uploadUriAsMultipart(uri: Uri) {
         val resolver = requireContext().contentResolver

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
+import com.example.bisit.MainActivity
 import com.example.bisit.R
 import com.example.bisit.data.api.RetrofitClient
 import com.example.bisit.data.repository.staffManage.StaffManageRepository
@@ -23,12 +24,10 @@ class ShopFragment : Fragment() {
     private var _binding: FragmentShopBinding? = null
     private val binding get() = _binding!!
 
-    /** shopId 단일 소스 (Activity scope) */
     private val shopRegisterViewModel: ShopRegisterViewModel by activityViewModels {
         ShopRegisterViewModelFactory(requireContext().applicationContext)
     }
 
-    /** 직원 신청 상태 ViewModel (뱃지 표시용) */
     private lateinit var staffRequestViewModel: ShopStaffRequestViewModel
 
     override fun onCreateView(
@@ -45,11 +44,57 @@ class ShopFragment : Fragment() {
 
         setupStaffRequestViewModel()
         setupViewPagerAndTabs()
-        setupStaffApplyNavigation()     // ⭐️ 무조건 이동
-        observeShopIdForBadgeOnly()     // ⭐️ 뱃지 표시만
+        setupStaffApplyNavigation()
+        observeShopIdForBadgeOnly()
         observeStaffRequestState()
 
         updateTabUI(0)
+
+        // 🔥 온보딩 체크
+        binding.root.post {
+            checkOnboardingStep()
+        }
+    }
+
+    /* ===================== 온보딩 처리 ===================== */
+
+    private fun checkOnboardingStep() {
+
+        val activity = requireActivity() as MainActivity
+
+        when (activity.currentGuideStep) {
+
+            MainActivity.GuideStep.TAB -> {
+                activity.showGlobalOverlay(
+                    targetView = binding.tabContainer,
+                    guideText = "탭을 눌러 화면을 이동할 수 있어요.",
+                    shape = HighlightOverlayView.HighlightShape.ROUNDED_RECT,
+                    radiusDp = 8f
+                )
+            }
+
+            MainActivity.GuideStep.EDIT_BUTTON -> {
+                activity.showGlobalOverlay(
+                    targetView = binding.viewPager,
+                    guideText = "수정 버튼을 눌러 매장 정보를 바꿀 수 있어요.",
+                    shape = HighlightOverlayView.HighlightShape.ROUNDED_RECT,
+                    radiusDp = 12f
+                )
+            }
+
+            MainActivity.GuideStep.SERVICE_TAB -> {
+                activity.showGlobalOverlay(
+                    targetView = binding.tabServices,
+                    guideText = "서비스 등록 탭에서 서비스를 추가해보세요.",
+                    shape = HighlightOverlayView.HighlightShape.ROUNDED_RECT,
+                    radiusDp = 12f
+                )
+            }
+
+            else -> {
+                activity.hideGlobalOverlay()
+            }
+        }
     }
 
     /* ===================== setup ===================== */
@@ -81,9 +126,6 @@ class ShopFragment : Fragment() {
         )
     }
 
-    /**
-     * 직원 신청 페이지는 조건 없이 항상 이동 가능
-     */
     private fun setupStaffApplyNavigation() {
         binding.ivStaffApply.setOnClickListener {
             findNavController().navigate(
@@ -94,17 +136,12 @@ class ShopFragment : Fragment() {
 
     /* ===================== observe ===================== */
 
-    /**
-     * shopId는 '새 직원 신청 있음/없음' 뱃지 표시 용도
-     * 네비게이션 / 접근 제어와는 무관
-     */
     private fun observeShopIdForBadgeOnly() {
         viewLifecycleOwner.lifecycleScope.launch {
             shopRegisterViewModel.shopId.collect { shopId ->
                 if (shopId != null) {
                     staffRequestViewModel.checkPendingStaffExists(shopId)
                 }
-                // shopId 없어도 아무것도 막지 않음
             }
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,8 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
+    <!-- ================= NavHost ================= -->
+
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
@@ -19,6 +21,8 @@
         app:layout_constraintTop_toTopOf="parent"
         app:navGraph="@navigation/nav_graph" />
 
+    <!-- ================= Bottom Divider ================= -->
+
     <View
         android:id="@+id/shadow_view"
         android:layout_width="0dp"
@@ -28,13 +32,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <!-- ================= Bottom Navigation ================= -->
+
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         style="@style/Widget.App.BottomNavigationView"
-        app:itemIconSize="34dp"
         android:background="@android:color/white"
+        app:itemIconSize="34dp"
         app:itemActiveIndicatorStyle="@android:color/transparent"
         app:itemRippleColor="@android:color/transparent"
         app:itemTextAppearanceActive="@style/BottomNavLabelStyle"
@@ -46,5 +52,30 @@
         app:menu="@menu/bottom_nav_menu"
         app:itemIconTint="@color/bottom_nav_item_color"
         app:itemTextColor="@color/bottom_nav_item_color"/>
+
+    <com.example.bisit.ui.shop.HighlightOverlayView
+        android:id="@+id/globalOverlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        android:clickable="true"
+        android:focusable="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- ================= 안내 텍스트 ================= -->
+
+    <TextView
+        android:id="@+id/globalGuideText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/white"
+        android:textSize="14sp"
+        android:padding="12dp"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_shop.xml
+++ b/app/src/main/res/layout/fragment_shop.xml
@@ -1,185 +1,202 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#F8F8F8">
+    android:layout_height="match_parent">
 
-    <!-- ================= 헤더 영역 ================= -->
+    <!-- ================= 기존 화면 ================= -->
     <LinearLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical"
-        android:layout_marginTop="39dp"
-        android:layout_marginBottom="16dp"
-        android:paddingStart="18dp"
-        android:paddingEnd="18dp">
+        android:layout_height="match_parent"
+        android:background="#F8F8F8">
 
-        <!-- 제목 -->
-        <TextView
-            android:id="@+id/tvTitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="매장 관리"
-            android:textColor="#222222"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            android:letterSpacing="0.04" />
-
-        <!-- 직원 신청 영역 -->
+        <!-- ================= 헤더 영역 ================= -->
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:gravity="center_vertical">
-
-            <!-- 말풍선 (새 직원 신청 있을 때만 표시) -->
-            <ImageView
-                android:id="@+id/ivStaffApplyBubble"
-                android:layout_width="130dp"
-                android:layout_height="26dp"
-                android:src="@drawable/ic_staff_apply_bubble"
-                android:visibility="gone"
-                android:contentDescription="새 직원 신청 안내" />
-
-            <!-- 직원 신청 아이콘 -->
-            <ImageView
-                android:id="@+id/ivStaffApply"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:layout_marginStart="4dp"
-                android:src="@drawable/ic_staff_apply"
-                android:contentDescription="직원 신청" />
-        </LinearLayout>
-    </LinearLayout>
-
-    <!-- ================= 탭 영역 ================= -->
-    <LinearLayout
-        android:id="@+id/tabContainer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center"
-        android:layout_marginTop="13dp">
-
-        <!-- 기본 -->
-        <LinearLayout
-            android:id="@+id/tabBasic"
-            android:orientation="vertical"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:layout_marginEnd="50dp">
+            android:gravity="center_vertical"
+            android:layout_marginTop="39dp"
+            android:layout_marginBottom="16dp"
+            android:paddingStart="18dp"
+            android:paddingEnd="18dp">
 
             <TextView
-                android:id="@+id/tvBasic"
+                android:id="@+id/tvTitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="매장 관리"
+                android:textColor="#222222"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.04" />
+
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/tab_basic"
-                android:textColor="#6D7583"
-                android:textSize="14sp"
-                android:paddingHorizontal="4dp" />
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
 
-            <View
-                android:id="@+id/indicatorBasic"
-                android:layout_width="match_parent"
-                android:layout_height="3dp"
-                android:layout_marginTop="10dp"
-                android:background="#4076FF" />
+                <ImageView
+                    android:id="@+id/ivStaffApplyBubble"
+                    android:layout_width="130dp"
+                    android:layout_height="26dp"
+                    android:src="@drawable/ic_staff_apply_bubble"
+                    android:visibility="gone"
+                    android:contentDescription="새 직원 신청 안내" />
+
+                <ImageView
+                    android:id="@+id/ivStaffApply"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="4dp"
+                    android:src="@drawable/ic_staff_apply"
+                    android:contentDescription="직원 신청" />
+            </LinearLayout>
         </LinearLayout>
 
-        <!-- 리뷰 -->
+        <!-- ================= 탭 영역 ================= -->
         <LinearLayout
-            android:id="@+id/tabReviews"
-            android:orientation="vertical"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:layout_marginEnd="50dp">
-
-            <TextView
-                android:id="@+id/tvReviews"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/tab_reviews"
-                android:textColor="#9AA1AF"
-                android:textSize="14sp"
-                android:paddingHorizontal="4dp" />
-
-            <View
-                android:id="@+id/indicatorReviews"
-                android:layout_width="match_parent"
-                android:layout_height="3dp"
-                android:layout_marginTop="10dp"
-                android:background="@android:color/transparent" />
-        </LinearLayout>
-
-        <!-- 서비스 등록 -->
-        <LinearLayout
-            android:id="@+id/tabServices"
-            android:orientation="vertical"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:layout_marginEnd="50dp">
-
-            <TextView
-                android:id="@+id/tvServices"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/tab_services"
-                android:textColor="#9AA1AF"
-                android:textSize="14sp"
-                android:paddingHorizontal="4dp" />
-
-            <View
-                android:id="@+id/indicatorServices"
-                android:layout_width="match_parent"
-                android:layout_height="3dp"
-                android:layout_marginTop="10dp"
-                android:background="@android:color/transparent" />
-        </LinearLayout>
-
-        <!-- 공지사항 -->
-        <LinearLayout
-            android:id="@+id/tabNotices"
-            android:orientation="vertical"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal">
-
-            <TextView
-                android:id="@+id/tvNotices"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/tab_notices"
-                android:textColor="#9AA1AF"
-                android:textSize="14sp"
-                android:paddingHorizontal="4dp" />
-
-            <View
-                android:id="@+id/indicatorNotices"
-                android:layout_width="match_parent"
-                android:layout_height="3dp"
-                android:layout_marginTop="10dp"
-                android:background="@android:color/transparent" />
-        </LinearLayout>
-    </LinearLayout>
-
-    <!-- ================= 콘텐츠 영역 ================= -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:background="#F0F2F5">
-
-        <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/viewPager"
+            android:id="@+id/tabContainer"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:layout_marginTop="13dp">
+
+            <LinearLayout
+                android:id="@+id/tabBasic"
+                android:orientation="vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:layout_marginEnd="50dp">
+
+                <TextView
+                    android:id="@+id/tvBasic"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/tab_basic"
+                    android:textColor="#6D7583"
+                    android:textSize="14sp"
+                    android:paddingHorizontal="4dp" />
+
+                <View
+                    android:id="@+id/indicatorBasic"
+                    android:layout_width="match_parent"
+                    android:layout_height="3dp"
+                    android:layout_marginTop="10dp"
+                    android:background="#4076FF" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/tabReviews"
+                android:orientation="vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:layout_marginEnd="50dp">
+
+                <TextView
+                    android:id="@+id/tvReviews"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/tab_reviews"
+                    android:textColor="#9AA1AF"
+                    android:textSize="14sp"
+                    android:paddingHorizontal="4dp" />
+
+                <View
+                    android:id="@+id/indicatorReviews"
+                    android:layout_width="match_parent"
+                    android:layout_height="3dp"
+                    android:layout_marginTop="10dp"
+                    android:background="@android:color/transparent" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/tabServices"
+                android:orientation="vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:layout_marginEnd="50dp">
+
+                <TextView
+                    android:id="@+id/tvServices"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/tab_services"
+                    android:textColor="#9AA1AF"
+                    android:textSize="14sp"
+                    android:paddingHorizontal="4dp" />
+
+                <View
+                    android:id="@+id/indicatorServices"
+                    android:layout_width="match_parent"
+                    android:layout_height="3dp"
+                    android:layout_marginTop="10dp"
+                    android:background="@android:color/transparent" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/tabNotices"
+                android:orientation="vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal">
+
+                <TextView
+                    android:id="@+id/tvNotices"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/tab_notices"
+                    android:textColor="#9AA1AF"
+                    android:textSize="14sp"
+                    android:paddingHorizontal="4dp" />
+
+                <View
+                    android:id="@+id/indicatorNotices"
+                    android:layout_width="match_parent"
+                    android:layout_height="3dp"
+                    android:layout_marginTop="10dp"
+                    android:background="@android:color/transparent" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <!-- ================= 콘텐츠 영역 ================= -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:background="#F0F2F5">
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/viewPager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </LinearLayout>
+
     </LinearLayout>
 
-</LinearLayout>
+    <!-- ================= 전체 화면 오버레이 ================= -->
+    <com.example.bisit.ui.shop.HighlightOverlayView
+        android:id="@+id/globalOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
+    <!-- 안내 텍스트 -->
+    <TextView
+        android:id="@+id/globalGuideText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/white"
+        android:textSize="14sp"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_shop_basic.xml
+++ b/app/src/main/res/layout/fragment_shop_basic.xml
@@ -394,4 +394,25 @@
             </LinearLayout>
         </LinearLayout>
     </ScrollView>
+
+    <com.example.bisit.ui.shop.HighlightOverlayView
+        android:id="@+id/highlightOverlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/guideText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/white"
+        android:textSize="14sp"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_overlay_skip.xml
+++ b/app/src/main/res/layout/view_overlay_skip.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/btnSkip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="건너뛰기"
+        android:textColor="#000"
+        android:textSize="14sp"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="40dp" />
+
+</FrameLayout>


### PR DESCRIPTION
## ✔️ 작업 내용

### 사장님(Owner) 전용 온보딩 기능 구현
사장님 계정으로 최초 로그인 시 매장 관리 기능을 단계별로 안내하는 온보딩 가이드를 구현했습니다.
- Owner 계정에서만 동작
- 최초 1회만 실행
- 완료 시 재노출되지 않음
- 진행 중 앱 종료 시 이어서 진행 가능

## 🏗 전체 구조
온보딩은 특정 Fragment 내부가 아닌 **MainActivity 전역에서 관리**하도록 설계했습니다.

MainActivity
 ├── NavHostFragment
 ├── BottomNavigationView
 ├── HighlightOverlayView (전역 오버레이)
 └── GuideStep 상태 관리

### 설계 이유

- BottomNavigation은 Activity에 존재
- 여러 Fragment를 넘나드는 단계 진행 필요
- 서비스 등록 화면 → 다시 매장 관리 화면 복귀 → 다음 단계 진행 구조 필요
- Fragment 단에서 처리 시 화면 전환 시 오버레이 상태 유지가 어려움
따라서:
- 온보딩 상태는 Activity가 전역 관리  
- 각 Fragment는 현재 단계에 맞는 View를 전달하는 구조로 구현

## 🔁 온보딩 전체 진행 흐름 (상세)

### ① 매장 관리 진입
- 사장님 로그인
- 시작 화면: `shopFragment`
- 상단 탭 전체 강조
- 안내: “탭을 눌러 화면을 이동할 수 있어요.”

화면 터치 → 다음 단계

### ② 매장 정보 수정 안내
- Basic 탭 영역 강조
- 안내: “수정 버튼을 눌러 매장 정보를 변경할 수 있어요.”
화면 터치 → 다음 단계

### ③ 서비스 등록 탭 강조
- Services 탭 강조
- 안내: “서비스 등록 탭에서 서비스를 추가해보세요.”
화면 터치 → 서비스 탭 자동 이동

### ④ 서비스 등록 화면 이동
- 실제 서비스 등록 화면으로 이동
- 이 단계에서는 단순 강조가 아니라 **실제 서비스 등록 동작을 유도**
- 사용자가 서비스를 등록해야 다음 흐름으로 진행 가능
- 서비스 등록 완료 시:
  - 다시 `shopFragment`로 복귀
  - 다음 단계 자동 진행

### ⑤ 오늘의 예약 탭 강조
- BottomNavigation의 "오늘의 예약" 탭 강조
- 안내: “오늘 들어온 예약을 확인할 수 있어요.”
화면 터치 → 오늘의 예약 화면 이동

### ⑥ 오늘의 예약 화면 설명
- 예약 리스트 영역 강조
- 안내 메시지 표시
화면 터치 → 다음 단계

### ⑦ 예약 내역 탭 강조
- 예약 내역 화면 내부 진행 없음
- 탭만 강조
- 화면 터치 시 바로 다음 단계로 이동
- 
### ⑧ 내 정보 탭 강조
- BottomNavigation의 "내 정보" 탭 강조
- 안내: “내 정보를 수정할 수 있어요.”
화면 터치 → 온보딩 종료

### ⑨ 종료
- 오버레이 제거
- SharedPreferences에 완료 상태 저장
- 다시 로그인해도 표시되지 않음

## 💾 상태 관리 방식
### 1️⃣ 단계 상태
`GuideStep enum` 으로 단계 관리
Activity가 현재 단계 보유

```
enum class GuideStep {
    TAB,              // 매장 관리 상단 탭 전체 강조
    EDIT_BUTTON,      // 매장 정보 수정 영역 강조
    SERVICE_TAB,      // 서비스 등록 탭 강조
    SERVICE_SCREEN,   // 서비스 등록 화면 진입 및 등록 유도
    TODAY_TAB,        // 오늘의 예약 탭 강조 (BottomNavigation)
    TODAY_SCREEN,     // 오늘의 예약 화면 내부 안내
    MY_TAB,           // 내 정보 탭 강조
    DONE              // 온보딩 종료 상태
}
```

### 2️⃣ 완료 여부 저장
SharedPreferences 사용
key: `owner_onboarding_done`
- 완료 시 true 저장
- 앱 재실행 시 확인
- true면 온보딩 미노출

## 👤 사용자 시나리오
- 최초 로그인 (Owner) → 온보딩 자동 시작
- 온보딩 완료 후 재로그인 → 온보딩 표시되지 않음
- 온보딩 중 앱 종료 → 재로그인 시 해당 단계부터 재개

## 🎯 UX 설계 포인트
- Next 버튼 없이 화면 터치로 자연스럽게 진행
- Skip 버튼으로 즉시 종료 가능
- BottomNavigation 자동 이동으로 흐름 단절 최소화
- 실제 서비스 등록을 유도하여 기능 학습 효과 강화

## 💬 참고 사항
- Owner 계정에서만 동작하도록 분기 처리했습니다.
- Activity 중심 구조로 설계하여 Fragment 간 상태 동기화 문제를 해결했습니다.
- 향후 GuideStep enum 확장 시 다른 역할(User 등) 온보딩 추가 가능합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * Owner 사용자를 위한 온보딩 플로우 추가
  * 단계별 가이드 오버레이로 주요 기능 강조
  * 언제든지 건너뛸 수 있는 스킵 기능 제공
  * 온보딩 완료 상태 자동 저장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->