### PR TITLE
feat: FCM 푸시 알림 구현 (예약 시 사장님 알림)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     id("kotlin-kapt")
+    id("com.google.gms.google-services")
 }
 
 val localProps = Properties()
@@ -130,4 +131,8 @@ dependencies {
     // log
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+
+    // Firebase
+    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
+    implementation("com.google.firebase:firebase-messaging-ktx")
 }

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "282259436178",
+    "project_id": "bisit-c5c5c",
+    "storage_bucket": "bisit-c5c5c.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:282259436178:android:f819e13997542040e0ec4b",
+        "android_client_info": {
+          "package_name": "com.example.bisit"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA8_GR4yU9kxKzzAxbycyteqy975bYK8ME"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -71,7 +72,15 @@
             android:exported="false"
             android:label="소셜 로그인"
             android:theme="@style/Theme.Bisit" />
-            
+
+        <service
+            android:name=".service.BisitFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/bisit/data/api/MemberApiService.kt
+++ b/app/src/main/java/com/example/bisit/data/api/MemberApiService.kt
@@ -1,5 +1,6 @@
 package com.example.bisit.data.api
 
+import com.example.bisit.data.model.member.FcmTokenRequest
 import com.example.bisit.data.model.member.MemberRoleRequest
 import com.example.bisit.data.model.member.MemberRoleResponse
 import com.example.bisit.data.model.member.MyPageResponse
@@ -8,6 +9,7 @@ import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
+import retrofit2.http.PUT
 
 interface MemberApiService {
     @GET("/api/members/my-page")
@@ -23,4 +25,9 @@ interface MemberApiService {
     fun updateMemberRole(
         @Body request: MemberRoleRequest
     ): Call<MemberRoleResponse>
+
+    @PUT("/api/members/fcm-token")
+    fun updateFcmToken(
+        @Body request: FcmTokenRequest
+    ): Call<Void>
 }

--- a/app/src/main/java/com/example/bisit/data/model/member/FcmTokenRequest.kt
+++ b/app/src/main/java/com/example/bisit/data/model/member/FcmTokenRequest.kt
@@ -1,0 +1,5 @@
+package com.example.bisit.data.model.member
+
+data class FcmTokenRequest(
+    val fcmToken: String
+)

--- a/app/src/main/java/com/example/bisit/service/BisitFirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/bisit/service/BisitFirebaseMessagingService.kt
@@ -1,0 +1,97 @@
+package com.example.bisit.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.example.bisit.MainActivity
+import com.example.bisit.R
+import com.example.bisit.data.api.RetrofitClient
+import com.example.bisit.data.api.TokenManager
+import com.example.bisit.data.model.member.FcmTokenRequest
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class BisitFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        Log.d(TAG, "FCM 토큰 갱신: $token")
+
+        val accessToken = TokenManager.getAccessToken(this)
+        if (!accessToken.isNullOrBlank()) {
+            sendTokenToServer(this, token)
+        }
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+        Log.d(TAG, "FCM 메시지 수신: ${message.notification?.title}")
+
+        message.notification?.let {
+            showNotification(it.title ?: "Bisit", it.body ?: "")
+        }
+    }
+
+    private fun showNotification(title: String, body: String) {
+        val channelId = "bisit_reservation"
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                "예약 알림",
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        notificationManager.notify(System.currentTimeMillis().toInt(), notification)
+    }
+
+    companion object {
+        private const val TAG = "BisitFCM"
+
+        fun sendTokenToServer(context: Context, token: String) {
+            RetrofitClient.getMemberApi(context)
+                .updateFcmToken(FcmTokenRequest(token))
+                .enqueue(object : Callback<Void> {
+                    override fun onResponse(call: Call<Void>, response: Response<Void>) {
+                        if (response.isSuccessful) {
+                            Log.d(TAG, "FCM 토큰 서버 등록 성공")
+                        } else {
+                            Log.e(TAG, "FCM 토큰 서버 등록 실패: ${response.code()}")
+                        }
+                    }
+
+                    override fun onFailure(call: Call<Void>, t: Throwable) {
+                        Log.e(TAG, "FCM 토큰 서버 등록 네트워크 오류", t)
+                    }
+                })
+        }
+    }
+}

--- a/app/src/main/java/com/example/bisit/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/bisit/ui/login/LoginViewModel.kt
@@ -11,6 +11,8 @@ import com.example.bisit.data.api.TokenManager
 import com.example.bisit.data.model.auth.LoginRequest
 import com.example.bisit.data.model.auth.LoginResponse
 import com.example.bisit.data.model.member.MyPageResponse
+import com.example.bisit.service.BisitFirebaseMessagingService
+import com.google.firebase.messaging.FirebaseMessaging
 import org.json.JSONObject
 import retrofit2.Call
 import retrofit2.Callback
@@ -87,7 +89,10 @@ class LoginViewModel : ViewModel() {
                     // 3. memberId 저장
                     TokenManager.saveMemberId(context, memberId)
 
-                    // 4. 최종 로그인 성공 처리 (모든 정보가 다 저장된 후)
+                    // 4. FCM 토큰 등록
+                    registerFcmToken(context)
+
+                    // 5. 최종 로그인 성공 처리 (모든 정보가 다 저장된 후)
                     _loginResult.value = true
                 } else {
                     _errorMessage.value = "사용자 정보를 가져오는 데 실패했습니다."
@@ -100,6 +105,15 @@ class LoginViewModel : ViewModel() {
                 _loginResult.value = false
             }
         })
+    }
+
+    private fun registerFcmToken(context: Context) {
+        FirebaseMessaging.getInstance().token.addOnSuccessListener { token ->
+            Log.d("LoginViewModel", "FCM 토큰 획득: $token")
+            BisitFirebaseMessagingService.sendTokenToServer(context, token)
+        }.addOnFailureListener { e ->
+            Log.e("LoginViewModel", "FCM 토큰 획득 실패", e)
+        }
     }
 
     // JWT 토큰에서 Role 정보를 읽어오는 헬퍼 함수

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }


### PR DESCRIPTION
## Summary
- Firebase Cloud Messaging 연동
- 로그인 시 FCM 토큰 자동 서버 등록
- 푸시 알림 수신 및 Notification 표시

## 변경 파일
- `build.gradle.kts` (루트/앱) — Firebase 플러그인 및 의존성 추가
- `google-services.json` — Firebase 설정 파일 배치
- `AndroidManifest.xml` — POST_NOTIFICATIONS 퍼미션 + FCM 서비스 등록
- `BisitFirebaseMessagingService.kt` — 토큰 갱신/메시지 수신 처리
- `FcmTokenRequest.kt` — FCM 토큰 요청 DTO
- `MemberApiService.kt` — PUT /api/members/fcm-token API 추가
- `LoginViewModel.kt` — 로그인 성공 후 FCM 토큰 등록

## Test plan
- [ ] 앱 빌드 성공 확인
- [ ] 로그인 후 FCM 토큰 서버 등록 확인
- [ ] 예약 생성 시 사장님 앱에서 푸시 알림 수신 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 푸시 알림 기능이 추가되었습니다.
  * 로그인 완료 시 기기가 자동으로 서버에 등록됩니다.
  * 수신한 메시지가 기기의 알림으로 즉시 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->