### PR TITLE
[Feature/#133] shop & todayReserve 온보딩 연동

### DIFF
--- a/app/src/main/java/com/example/bisit/MainActivity.kt
+++ b/app/src/main/java/com/example/bisit/MainActivity.kt
@@ -17,6 +17,7 @@ import com.example.bisit.ui.shop.HighlightOverlayView
 import com.example.bisit.ui.shop.ShopBasicFragment
 import com.example.bisit.ui.shop.ShopFragment
 import com.example.bisit.ui.shop.ShopServicesFragment
+import com.example.bisit.ui.todayReserv.TodayReservFragment
 
 class MainActivity : AppCompatActivity() {
 
@@ -227,6 +228,7 @@ class MainActivity : AppCompatActivity() {
                         when (child) {
                             is ShopBasicFragment -> child.refreshOnboarding()
                             is ShopServicesFragment -> child.refreshOnboarding()
+                            is TodayReservFragment -> child.refreshOnboarding()
                         }
                     }
                 }
@@ -292,6 +294,25 @@ class MainActivity : AppCompatActivity() {
                 0f
             )
         }
+    }
+
+    fun getBottomNavHighlightRect(index: Int, sizeDp: Float = 72f): RectF? {
+        val menuView = binding.bottomNavView.getChildAt(0) as? ViewGroup ?: return null
+        val itemView = menuView.getChildAt(index) ?: return null
+
+        val rect = Rect()
+        itemView.getGlobalVisibleRect(rect)
+
+        val size = sizeDp * resources.displayMetrics.density
+        val cx = rect.centerX()
+        val cy = rect.centerY()
+
+        return RectF(
+            cx - size / 2f,
+            cy - size / 2f,
+            cx + size / 2f,
+            cy + size / 2f
+        )
     }
 
     fun hideGlobalOverlay() {

--- a/app/src/main/java/com/example/bisit/MainActivity.kt
+++ b/app/src/main/java/com/example/bisit/MainActivity.kt
@@ -16,12 +16,12 @@ import com.example.bisit.databinding.ActivityMainBinding
 import com.example.bisit.ui.shop.HighlightOverlayView
 import com.example.bisit.ui.shop.ShopBasicFragment
 import com.example.bisit.ui.shop.ShopFragment
+import com.example.bisit.ui.shop.ShopServicesFragment
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
 
-    /* 🔥 추가된 것 */
     private lateinit var globalOverlay: HighlightOverlayView
     private lateinit var globalGuideTextLayer: FrameLayout
 
@@ -57,9 +57,6 @@ class MainActivity : AppCompatActivity() {
 
         val decorView = window.decorView as ViewGroup
 
-        /* ===============================
-           🔥 1. Overlay 최상단 추가
-        =============================== */
         globalOverlay = HighlightOverlayView(this)
         decorView.addView(
             globalOverlay,
@@ -72,9 +69,6 @@ class MainActivity : AppCompatActivity() {
         globalOverlay.elevation = 9999f
         globalOverlay.visibility = View.GONE
 
-        /* ===============================
-           🔥 2. 텍스트 레이어를 Overlay 위에 추가
-        =============================== */
         globalGuideTextLayer = FrameLayout(this)
         globalGuideTextLayer.layoutParams =
             ViewGroup.LayoutParams(
@@ -230,8 +224,9 @@ class MainActivity : AppCompatActivity() {
                     fragment.refreshOnboarding()
 
                     fragment.childFragmentManager.fragments.forEach { child ->
-                        if (child is ShopBasicFragment) {
-                            child.refreshOnboarding()
+                        when (child) {
+                            is ShopBasicFragment -> child.refreshOnboarding()
+                            is ShopServicesFragment -> child.refreshOnboarding()
                         }
                     }
                 }
@@ -301,6 +296,11 @@ class MainActivity : AppCompatActivity() {
 
     fun hideGlobalOverlay() {
         globalOverlay.visibility = View.GONE
+        globalOverlay.clearHighlight()
+    }
+
+    fun showDimOnlyOverlay() {
+        globalOverlay.visibility = View.VISIBLE
         globalOverlay.clearHighlight()
     }
 

--- a/app/src/main/java/com/example/bisit/data/repository/todayReservation/FakeTodayReservationData.kt
+++ b/app/src/main/java/com/example/bisit/data/repository/todayReservation/FakeTodayReservationData.kt
@@ -1,0 +1,62 @@
+package com.example.bisit.data.repository.todayReservation
+
+import com.example.bisit.data.model.todayReservation.*
+
+object FakeTodayReservationData {
+
+    fun pendingOneItemResponse(
+        tab: String = "pending",
+        sortBy: String = "recent"
+    ): CommonResponse<TodayReservationData> {
+
+        val one = ReservationItem(
+            reservationId = 9999L,
+            status = "PENDING",
+            serviceStatus = "WAITING",
+            customerName = "김손님",
+            treatmentName = "기본 시술",
+            staffName = "김사장",
+            visitAddressLine = "서울시 어딘가 1-1",
+            reservedDate = "2026-01-01",
+            startTime = "01:01"
+        )
+
+        val data = TodayReservationData(
+            reservations = listOf(one),
+            tab = tab,
+            sortBy = sortBy,
+            totalCount = 1
+        )
+
+        return CommonResponse(
+            code = "200",
+            success = true,
+            message = "onboarding mock",
+            data = data
+        )
+    }
+
+    fun statusOkResponse(): CommonResponse<TodayReservationStatusData> {
+        val data = TodayReservationStatusData(
+            status = "APPROVED",
+            serviceStatus = "READY",
+            reservationId = 9999L,
+            paymentStatus = "UNPAID",
+            treatmentName = "기본 시술",
+            reservedDate = "2026-01-01",
+            startTime = "01:01",
+            customerName = "김손님",
+            customerPhone = "010-0000-0000",
+            customerAddress = "서울시 어딘가 1-1",
+            staffName = "김사장",
+            price = 10000
+        )
+
+        return CommonResponse(
+            code = "200",
+            success = true,
+            message = "onboarding mock status ok",
+            data = data
+        )
+    }
+}

--- a/app/src/main/java/com/example/bisit/data/repository/todayReservation/TodayReservationRepository.kt
+++ b/app/src/main/java/com/example/bisit/data/repository/todayReservation/TodayReservationRepository.kt
@@ -7,13 +7,29 @@ class TodayReservationRepository(
     private val api: TodayReservationApiService
 ) {
 
+    var onboardingMode: Boolean = false
+        private set
+
+    fun setOnboardingMode(enabled: Boolean) {
+        onboardingMode = enabled
+    }
+
     // 오늘의 예약 조회
     suspend fun getTodayReservations(
         shopId: Long,
         tab: String,
         sortBy: String
     ): CommonResponse<TodayReservationData> {
-        return api.getTodayReservations(shopId, tab, sortBy)
+
+        if (onboardingMode) {
+            return FakeTodayReservationData.pendingOneItemResponse(sortBy)
+        }
+
+        return api.getTodayReservations(
+            shopId = shopId,
+            tab = tab,
+            sortBy = sortBy
+        )
     }
 
     // 예약 상태 변경
@@ -21,6 +37,9 @@ class TodayReservationRepository(
         reservationId: Long,
         body: ChangeStatusRequest
     ): CommonResponse<TodayReservationStatusData> {
+        if (onboardingMode) {
+            return FakeTodayReservationData.statusOkResponse()
+        }
         return api.changeStatus(reservationId, body)
     }
 
@@ -29,6 +48,9 @@ class TodayReservationRepository(
         reservationId: Long,
         body: RejectReservationRequest
     ): CommonResponse<TodayReservationStatusData> {
+        if (onboardingMode) {
+            return FakeTodayReservationData.statusOkResponse()
+        }
         return api.rejectReservation(reservationId, body)
     }
 
@@ -36,6 +58,9 @@ class TodayReservationRepository(
     suspend fun approveReservation(
         reservationId: Long
     ): CommonResponse<TodayReservationStatusData> {
+        if (onboardingMode) {
+            return FakeTodayReservationData.statusOkResponse()
+        }
         return api.approveReservation(reservationId)
     }
 }

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopFragment.kt
@@ -84,11 +84,12 @@ class ShopFragment : Fragment() {
                         radiusDp = 50f
                     )
 
-                    showTextBelow(
+                    showTextBelowFixedLeft(
                         targetView = binding.tabServices,
-                        big = "안녕하세요 사장님!\n" + "우선 우리 가게 서비스를 등록해볼까요?",
-                        small = "밝은 곳을 터치해서\n 매장 시술을 등록해보세요.",
-                        bottomMarginDp = 24f
+                        big = "안녕하세요 사장님!\n우선 우리 가게 서비스를 등록해볼까요?",
+                        small = "밝은 곳을 터치해서 매장 시술을 등록해보세요.",
+                        bottomMarginDp = 24f,
+                        leftMarginDp = 18f
                     )
                 }
 
@@ -102,8 +103,8 @@ class ShopFragment : Fragment() {
                     activity.highlightBottomNavItem(index = 1)
 
                     showTextCenterAbove(
-                        big = "오늘 예약 확인",
-                        small = "오늘 예약을 눌러 확인해보세요."
+                        big = "이곳에서 오늘 들어온 예약을 볼 수 있어요.",
+                        small = ""
                     )
                 }
 
@@ -212,6 +213,41 @@ class ShopFragment : Fragment() {
         }
     }
 
+    private fun showTextBelowFixedLeft(
+        targetView: View,
+        big: String,
+        small: String,
+        bottomMarginDp: Float,
+        leftMarginDp: Float = 18f
+    ) {
+        val guideLayer = getGuideLayer()
+        guideLayer.removeAllViews()
+        guideLayer.visibility = View.VISIBLE
+
+        val bigText = createBigText(big)
+        val smallText = createSmallText(small)
+
+        guideLayer.addView(bigText)
+        guideLayer.addView(smallText)
+
+        bigText.post {
+            val rect = Rect()
+            targetView.getGlobalVisibleRect(rect)
+
+            val layerLocation = IntArray(2)
+            guideLayer.getLocationOnScreen(layerLocation)
+
+            val fixedLeft = dp(leftMarginDp)
+
+            val top = rect.bottom - layerLocation[1] + dp(bottomMarginDp)
+
+            bigText.x = fixedLeft
+            bigText.y = top
+
+            smallText.x = fixedLeft
+            smallText.y = top + dp(64f)
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopFragment.kt
@@ -2,11 +2,14 @@ package com.example.bisit.ui.shop
 
 import android.graphics.Color
 import android.graphics.Rect
+import android.graphics.RectF
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.*
 import android.widget.FrameLayout
 import android.widget.TextView
+import android.widget.ImageView
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.toColorInt
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -102,10 +105,15 @@ class ShopFragment : Fragment() {
 
                     activity.highlightBottomNavItem(index = 1)
 
-                    showTextCenterAbove(
-                        big = "이곳에서 오늘 들어온 예약을 볼 수 있어요.",
-                        small = ""
-                    )
+                    val rect = activity.getBottomNavHighlightRect(index = 1)
+                    if (rect != null) {
+                        showTodayTabGuideWithPigTail(
+                            highlightRect = rect,
+                            big = "이곳에서 오늘 들어온 예약을 볼 수 있어요."
+                        )
+                    } else {
+                        clearGuide()
+                    }
                 }
 
                 else -> clearGuide()
@@ -186,30 +194,87 @@ class ShopFragment : Fragment() {
         }
     }
 
-    private fun showTextCenterAbove(
+    private fun showTodayTabGuideWithPigTail(
+        highlightRect: RectF,
         big: String,
-        small: String
+        tailToTextGapDp: Float = 10f
     ) {
-
         val guideLayer = getGuideLayer()
         guideLayer.removeAllViews()
         guideLayer.visibility = View.VISIBLE
 
+        val tail = ImageView(requireContext()).apply {
+            setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.ic_pig_tail))
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        }
+
         val bigText = createBigText(big)
-        val smallText = createSmallText(small)
 
+        guideLayer.addView(tail)
         guideLayer.addView(bigText)
-        guideLayer.addView(smallText)
 
-        bigText.post {
+        // guideLayer가 레이아웃 된 다음에 좌표 계산
+        guideLayer.post {
 
-            val centerX = guideLayer.width / 2f
+            val layerLocation = IntArray(2)
+            guideLayer.getLocationOnScreen(layerLocation)
 
-            bigText.x = centerX - bigText.width / 2f
-            bigText.y = guideLayer.height * 0.55f
+            // highlightRect(스크린 좌표) -> guideLayer 로컬 좌표로 변환
+            val cx = highlightRect.centerX() - layerLocation[0]
+            val topOfCircle = highlightRect.top - layerLocation[1]
 
-            smallText.x = centerX - smallText.width / 2f
-            smallText.y = bigText.y + dp(64f)
+            val gap = dp(tailToTextGapDp)
+
+            // tail 위치: 원의 top에 "바로 붙여" 올림 (tail의 bottom == 원 top)
+            tail.measure(
+                View.MeasureSpec.makeMeasureSpec(guideLayer.width, View.MeasureSpec.AT_MOST),
+                View.MeasureSpec.makeMeasureSpec(guideLayer.height, View.MeasureSpec.AT_MOST)
+            )
+            val tailW = tail.measuredWidth.toFloat()
+            val tailH = tail.measuredHeight.toFloat()
+
+            var tailX = cx - tailW / 2f
+            var tailY = topOfCircle - tailH
+
+            // 텍스트 위치: tail 위로 10dp
+            bigText.measure(
+                View.MeasureSpec.makeMeasureSpec(guideLayer.width, View.MeasureSpec.AT_MOST),
+                View.MeasureSpec.makeMeasureSpec(guideLayer.height, View.MeasureSpec.AT_MOST)
+            )
+            val textW = bigText.measuredWidth.toFloat()
+            val textH = bigText.measuredHeight.toFloat()
+
+            var textX = cx - textW / 2f
+            var textY = tailY - gap - textH
+
+            // 화면 밖으로 안 나가게 clamp (최소 18dp 정도 여백)
+            val margin = dp(18f)
+            val maxXForTail = guideLayer.width - tailW - margin
+            val maxXForText = guideLayer.width - textW - margin
+
+            tailX = tailX.coerceIn(margin, maxXForTail)
+            textX = textX.coerceIn(margin, maxXForText)
+
+            // Y도 너무 위로 가면 조금 내려줌(원하는대로 조절 가능)
+            val minY = margin
+            if (textY < minY) {
+                // textY가 너무 위면 tail/text를 같이 아래로 내림
+                val delta = (minY - textY)
+                textY += delta
+                tailY += delta
+            }
+
+            tail.x = tailX
+            tail.y = tailY
+
+            bigText.x = textX
+            bigText.y = textY
+
+            tail.bringToFront()
+            bigText.bringToFront()
         }
     }
 

--- a/app/src/main/java/com/example/bisit/ui/shop/ShopServicesFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/ShopServicesFragment.kt
@@ -23,6 +23,7 @@ import com.example.bisit.util.uriToMultipart
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import okhttp3.MultipartBody
+import android.graphics.Typeface
 
 class ShopServicesFragment : Fragment() {
 
@@ -40,6 +41,10 @@ class ShopServicesFragment : Fragment() {
     }
 
     private var shopId: Long? = null
+
+    private fun getGuideLayer(): ViewGroup {
+        return (requireActivity() as MainActivity).getGlobalGuideLayer()
+    }
 
     /* ===================== Lifecycle ===================== */
 
@@ -60,8 +65,9 @@ class ShopServicesFragment : Fragment() {
         observeServiceList()
         observeError()
 
+        // ✅ 일반 동작: 사용자가 그냥 눌러도 모달 열리게 유지
         binding.fabAdd.setOnClickListener {
-            openAddServiceDialog()
+            openAddServiceDialogNormal()
         }
     }
 
@@ -78,7 +84,6 @@ class ShopServicesFragment : Fragment() {
                 showActionSheet(item)
             }
         )
-
         binding.rvServices.layoutManager = LinearLayoutManager(requireContext())
         binding.rvServices.adapter = adapter
     }
@@ -90,10 +95,7 @@ class ShopServicesFragment : Fragment() {
             shopRegisterViewModel.shopId.collectLatest { id ->
                 id?.let {
                     shopId = it
-                    shopServiceViewModel.loadTreatments(
-                        shopId = it,
-                        isFirst = true
-                    )
+                    shopServiceViewModel.loadTreatments(shopId = it, isFirst = true)
                 }
             }
         }
@@ -131,14 +133,8 @@ class ShopServicesFragment : Fragment() {
             viewLifecycleOwner
         ) { _, bundle ->
             when (bundle.getString(BottomActionSheet.RESULT_ACTION)) {
-
-                BottomActionSheet.ACTION_DELETE -> {
-                    showDeleteConfirm(item)
-                }
-
-                BottomActionSheet.ACTION_EDIT -> {
-                    openEditServiceDialog(item)
-                }
+                BottomActionSheet.ACTION_DELETE -> showDeleteConfirm(item)
+                BottomActionSheet.ACTION_EDIT -> openEditServiceDialog(item)
             }
         }
     }
@@ -159,50 +155,47 @@ class ShopServicesFragment : Fragment() {
         ).show(parentFragmentManager, "confirm_delete")
     }
 
-    /* ===================== 서비스 추가 ===================== */
+    /* ===================== 서비스 추가/수정(기존 로직 유지) ===================== */
 
-    private fun openAddServiceDialog() {
-        AddServiceDialog { treatment, imageUri ->
+    private fun openAddServiceDialogNormal() {
+        AddServiceDialog(
+            onSaved = { treatment, imageUri ->
+                val photoPart: MultipartBody.Part? =
+                    imageUri?.let { uriToMultipart(requireContext(), it, "photo") }
 
-            val photoPart: MultipartBody.Part? =
-                imageUri?.let {
-                    uriToMultipart(requireContext(), it, "photo")
+                shopId?.let {
+                    shopServiceViewModel.createTreatment(
+                        shopId = it,
+                        request = treatment.toRequest(),
+                        photo = photoPart
+                    )
                 }
-
-            shopId?.let {
-                shopServiceViewModel.createTreatment(
-                    shopId = it,
-                    request = treatment.toRequest(),
-                    photo = photoPart
-                )
             }
-        }.show(parentFragmentManager, "add_service")
+        ).show(parentFragmentManager, "add_service")
     }
-
-    /* ===================== 서비스 수정 ===================== */
 
     private fun openEditServiceDialog(item: TreatmentResponse) {
-        AddServiceDialog(prefill = item) { updated, imageUri ->
+        AddServiceDialog(
+            prefill = item,
+            onSaved = { updated, imageUri ->
+                val photoPart: MultipartBody.Part? =
+                    imageUri?.let { uriToMultipart(requireContext(), it, "photo") }
 
-            val photoPart: MultipartBody.Part? =
-                imageUri?.let {
-                    uriToMultipart(requireContext(), it, "photo")
+                shopId?.let {
+                    shopServiceViewModel.updateTreatment(
+                        treatmentId = updated.treatmentId,
+                        shopId = it,
+                        request = updated.toRequest(),
+                        photo = photoPart
+                    )
                 }
-
-            shopId?.let {
-                shopServiceViewModel.updateTreatment(
-                    treatmentId = updated.treatmentId,
-                    shopId = it,
-                    request = updated.toRequest(),
-                    photo = photoPart
-                )
             }
-        }.show(parentFragmentManager, "edit_service")
+        ).show(parentFragmentManager, "edit_service")
     }
 
+    /* ===================== Onboarding ===================== */
 
     fun refreshOnboarding() {
-
         val activity = requireActivity() as MainActivity
 
         if (!activity.isOnboardingActive()) {
@@ -211,58 +204,175 @@ class ShopServicesFragment : Fragment() {
         }
 
         binding.fabAdd.post {
+            when (activity.currentGuideStep) {
 
-            if (activity.currentGuideStep ==
-                MainActivity.GuideStep.SERVICE_SCREEN
-            ) {
+                // 1) FAB 동그라미 + "이곳을 누르세요!"
+                MainActivity.GuideStep.SERVICE_SCREEN -> {
+                    activity.showGlobalOverlay(
+                        targetView = binding.fabAdd,
+                        shape = HighlightOverlayView.HighlightShape.CIRCLE,
+                        radiusDp = 40f
+                    )
+                    showGuideTextAboveFab(binding.fabAdd, "이곳을 누르세요!")
+                }
 
-                activity.showGlobalOverlay(
-                    targetView = binding.fabAdd,
-                    shape = HighlightOverlayView.HighlightShape.CIRCLE,
-                    radiusDp = 40f
-                )
+                // 2) 모달 뜨기 직전 안내(텍스트만, 상단 160dp / left 18dp)
+                MainActivity.GuideStep.SERVICE_MODAL_GUIDE -> {
+                    activity.showDimOnlyOverlay() // 딤 + 버튼 유지 (구멍 없음)
+                    showModalGuideTextTop(
+                        big = "본격적으로 시술을 등록해볼까요?",
+                        small = "더 쾌적한 이용을 위해 모든 입력창을 채워주세요."
+                    )
+                }
 
-                showGuideTextAboveFab(binding.fabAdd)
+                // 3) 안내 끝 → 오버레이/텍스트 제거 → 모달 실제 오픈
+                MainActivity.GuideStep.SERVICE_MODAL_OPEN -> {
+                    activity.hideGlobalOverlay()
+                    clearGuide()
+                    openAddServiceDialogForOnboarding() // ✅ 닫히면 TODAY_TAB로
+                }
+
+                else -> {
+                    // 다른 단계는 여기서 관여 X (필요하면 정리만)
+                }
             }
         }
     }
 
-    private fun showGuideTextAboveFab(targetView: View) {
-
-        clearGuide()
-        binding.guideLayer.visibility = View.VISIBLE
+    // SERVICE_SCREEN 텍스트(기존 동작 유지)
+    private fun showGuideTextAboveFab(targetView: View, text: String) {
+        val guideLayer = getGuideLayer()
+        guideLayer.removeAllViews()
+        guideLayer.visibility = View.VISIBLE
 
         val guideText = TextView(requireContext()).apply {
-            text = "이곳을 누르세요!"
+            this.text = text
             setTextColor(0xFFFFFFFF.toInt())
             setTextSize(TypedValue.COMPLEX_UNIT_SP, 18f)
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
         }
 
-        binding.guideLayer.addView(guideText)
+        guideLayer.addView(guideText)
 
-        guideText.post {
+        guideLayer.post {
+            guideText.post {
+                val rect = Rect()
+                targetView.getGlobalVisibleRect(rect)
 
-            val rect = Rect()
-            targetView.getGlobalVisibleRect(rect)
+                val layerLocation = IntArray(2)
+                guideLayer.getLocationOnScreen(layerLocation)
 
-            val layerLocation = IntArray(2)
-            binding.guideLayer.getLocationOnScreen(layerLocation)
+                val margin18 = dp(18f)
 
-            val localRight = rect.right - layerLocation[0]
-            val localTop = rect.top - layerLocation[1]
+                val fabLeft = rect.left - layerLocation[0]
+                val fabTop = rect.top - layerLocation[1]
 
-            val margin8dp = 8 * resources.displayMetrics.density
-            val margin18dp = 18 * resources.displayMetrics.density
+                var x = fabLeft + (targetView.width / 2f) - (guideText.width / 2f)
+                var y = fabTop - guideText.height - margin18
 
-            guideText.x = localRight - guideText.width - margin18dp
-            guideText.y = localTop - guideText.height - margin8dp
+                val minX = margin18
+                val maxX = (guideLayer.width - guideText.width - margin18).toFloat()
+                val minY = margin18
+                val maxY = (guideLayer.height - guideText.height - margin18).toFloat()
+
+                if (maxX >= minX) x = x.coerceIn(minX, maxX)
+                if (maxY >= minY) y = y.coerceIn(minY, maxY)
+
+                guideText.x = x
+                guideText.y = y
+                guideText.bringToFront()
+            }
         }
+    }
+
+    // SERVICE_MODAL_GUIDE: 상단 고정 텍스트(동그라미 없음)
+    private fun showModalGuideTextTop(big: String, small: String) {
+        val guideLayer = getGuideLayer()
+        guideLayer.removeAllViews()
+        guideLayer.visibility = View.VISIBLE
+
+        val bigText = TextView(requireContext()).apply {
+            text = big
+            setTextColor(0xFFFFFFFF.toInt())
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 18f)
+            setTypeface(null, Typeface.BOLD)
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        }
+
+        val smallText = TextView(requireContext()).apply {
+            text = small
+            setTextColor(0xFFFFFFFF.toInt())
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        }
+
+        guideLayer.addView(bigText)
+        guideLayer.addView(smallText)
+
+        guideLayer.post {
+            val left = dp(18f)
+            val top = dp(180f)
+
+            bigText.x = left
+            bigText.y = top
+
+            smallText.x = left
+            smallText.y = top + dp(44f)
+
+            bigText.bringToFront()
+            smallText.bringToFront()
+        }
+    }
+
+    // SERVICE_MODAL_OPEN: 모달 열고, 닫히면(Tap X/추가하기) TODAY_TAB로 넘김
+    private fun openAddServiceDialogForOnboarding() {
+        val activity = requireActivity() as MainActivity
+
+        AddServiceDialog(
+            prefill = null,
+            onSaved = { treatment, imageUri ->
+                val photoPart: MultipartBody.Part? =
+                    imageUri?.let { uriToMultipart(requireContext(), it, "photo") }
+
+                shopId?.let {
+                    shopServiceViewModel.createTreatment(
+                        shopId = it,
+                        request = treatment.toRequest(),
+                        photo = photoPart
+                    )
+                }
+            },
+
+            onClosed = {
+                activity.currentGuideStep = MainActivity.GuideStep.TODAY_TAB
+                activity.hideGlobalOverlay()
+                clearGuide()
+                activity.refreshCurrentFragmentOverlay()
+            }
+        ).show(parentFragmentManager, "add_service_onboarding")
     }
 
     private fun clearGuide() {
-        binding.guideLayer.removeAllViews()
-        binding.guideLayer.visibility = View.GONE
+        val guideLayer = getGuideLayer()
+        guideLayer.removeAllViews()
+        guideLayer.visibility = View.GONE
     }
+
+    private fun dp(v: Float): Float =
+        TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            v,
+            resources.displayMetrics
+        )
 
     /* ===================== Cleanup ===================== */
 

--- a/app/src/main/java/com/example/bisit/ui/shop/dialog/AddServiceDialog.kt
+++ b/app/src/main/java/com/example/bisit/ui/shop/dialog/AddServiceDialog.kt
@@ -1,6 +1,7 @@
 package com.example.bisit.ui.shop.dialog
 
 import android.app.Activity
+import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -20,7 +21,8 @@ import com.example.bisit.data.model.shop.TreatmentResponse
 
 class AddServiceDialog(
     private val prefill: TreatmentResponse? = null,
-    private val onSaved: (TreatmentResponse, Uri?) -> Unit
+    private val onSaved: (TreatmentResponse, Uri?) -> Unit,
+    private val onClosed: (() -> Unit)? = null
 ) : DialogFragment() {
 
     private var _binding: DialogAddServiceBinding? = null
@@ -55,6 +57,12 @@ class AddServiceDialog(
         initInputWatcher()
         initClickListeners()
         updateButtonState(false)
+    }
+
+    // 어떤 방식으로 닫혀도( X / 추가하기 / 바깥 dismiss 등) 호출됨
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        onClosed?.invoke()
     }
 
     /* ===================== 초기화 ===================== */
@@ -122,7 +130,7 @@ class AddServiceDialog(
                 price = binding.etPrice.text.toString().toInt(),
                 durationHours = getHour(),
                 durationMinutes = getMinute(),
-                photoUrl = prefill?.photoUrl, // 서버에서 최종 갱신
+                photoUrl = prefill?.photoUrl,
                 isActive = true
             )
 
@@ -145,7 +153,6 @@ class AddServiceDialog(
 
             selectedImageUri = result.data?.data ?: return@registerForActivityResult
 
-            // ✅ 선택한 이미지 즉시 미리보기
             binding.ivImage.visibility = View.VISIBLE
             binding.ivAddImage.visibility = View.GONE
             binding.ivImage.setImageURI(selectedImageUri)

--- a/app/src/main/java/com/example/bisit/ui/todayReserv/PendingReservFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/todayReserv/PendingReservFragment.kt
@@ -18,11 +18,9 @@ import com.example.bisit.ui.todayReserv.dialog.ApproveCompleteDialog
 import com.example.bisit.ui.todayReserv.dialog.ChangeReasonDialog
 import kotlinx.coroutines.launch
 
-class PendingReservFragment : Fragment(), SortableFragment {
+class PendingReservFragment : Fragment(), SortableFragment, TodayApproveTargetProvider {
 
-    companion object {
-        private const val TAG = "PendingReserv"
-    }
+    companion object { private const val TAG = "PendingReserv" }
 
     private var _binding: FragmentPendingReservBinding? = null
     private val binding get() = _binding!!
@@ -31,8 +29,10 @@ class PendingReservFragment : Fragment(), SortableFragment {
     private var pendingList = mutableListOf<ReservationItem>()
 
     private var sortBy: String = "recent"
-
     private lateinit var repository: TodayReservationRepository
+
+    private var approveBtnForGuide: View? = null
+    override fun getApproveButtonForGuide(): View? = approveBtnForGuide
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -51,22 +51,23 @@ class PendingReservFragment : Fragment(), SortableFragment {
         sortBy = arguments?.getString("sortBy") ?: "recent"
         Log.d(TAG, "초기 sortBy: $sortBy")
 
-        // Repository 초기화
+        val activity = requireActivity() as com.example.bisit.MainActivity
+        val useMock = activity.isOnboardingActive()
+
         repository = TodayReservationRepository(
-            RetrofitClient.getTodayReservationApi(requireContext())
+            RetrofitClient.getTodayReservationApi(requireContext()),
         )
+
+        repository.setOnboardingMode(useMock)
 
         adapter = TodayReservationAdapter(
             currentTab = "pending",
 
-            // ✅ 승인
             onApprove = { item ->
                 lifecycleScope.launch {
                     try {
                         Log.d(TAG, "승인 요청: id=${item.reservationId}")
-
                         repository.approveReservation(item.reservationId)
-
                         Log.d(TAG, "승인 성공")
 
                         ApproveCompleteDialog().show(
@@ -74,37 +75,26 @@ class PendingReservFragment : Fragment(), SortableFragment {
                             "approve_complete"
                         )
 
-                        // 승인 후 다시 조회
                         fetchPendingReservations()
-
                     } catch (e: Exception) {
                         Log.e(TAG, "승인 실패", e)
                     }
                 }
             },
 
-            // ✅ 거절 (사유 포함)
             onReject = { item ->
                 ChangeReasonDialog { reason ->
                     lifecycleScope.launch {
                         try {
-                            Log.d(
-                                TAG,
-                                "거절 요청: id=${item.reservationId}, reason=$reason"
-                            )
+                            Log.d(TAG, "거절 요청: id=${item.reservationId}, reason=$reason")
 
                             repository.rejectReservation(
                                 reservationId = item.reservationId,
-                                body = RejectReservationRequest(
-                                    rejectionReason = reason
-                                )
+                                body = RejectReservationRequest(rejectionReason = reason)
                             )
 
                             Log.d(TAG, "거절 성공")
-
-                            // 거절 후 다시 조회
                             fetchPendingReservations()
-
                         } catch (e: Exception) {
                             Log.e(TAG, "거절 실패", e)
                         }
@@ -120,47 +110,60 @@ class PendingReservFragment : Fragment(), SortableFragment {
             adapter = this@PendingReservFragment.adapter
         }
 
-        // 최초 진입 시 조회
         fetchPendingReservations()
     }
 
-    /**
-     * 정렬 변경 시 호출
-     */
     override fun sort(sortBy: String) {
         this.sortBy = sortBy
         Log.d(TAG, "정렬 변경 요청: $sortBy")
         fetchPendingReservations()
     }
 
-    /**
-     * Pending 예약 조회 API
-     */
     private fun fetchPendingReservations() {
         lifecycleScope.launch {
             try {
                 Log.d(TAG, "Pending 예약 조회 API 호출")
 
                 val response = repository.getTodayReservations(
-                    shopId = 1L,   // TODO 실제 shopId
+                    shopId = 1L,
                     tab = "pending",
                     sortBy = sortBy
                 )
 
-                Log.d(TAG, "조회 성공: ${response.data}")
-
                 val reservations = response.data.reservations
                 pendingList = reservations.toMutableList()
+                adapter.submitList(pendingList.toList()) {
+                    binding.rvPendingList.post {
+                        binding.rvPendingList.scrollToPosition(0)
 
-                adapter.submitList(pendingList.toList())
+                        captureApproveButtonFromFirstItem()
+                    }
+                }
 
-                Log.d(
-                    TAG,
-                    "RecyclerView 갱신 완료 (size=${pendingList.size})"
-                )
+                Log.d(TAG, "RecyclerView 갱신 완료 (size=${pendingList.size})")
+
+                captureApproveButtonFromFirstItem()
 
             } catch (e: Exception) {
                 Log.e(TAG, "조회 실패", e)
+            }
+        }
+    }
+
+    private fun captureApproveButtonFromFirstItem() {
+        binding.rvPendingList.post {
+            val vh = binding.rvPendingList.findViewHolderForAdapterPosition(0)
+            approveBtnForGuide = vh?.itemView?.findViewById(com.example.bisit.R.id.btnApprove)
+
+            // 그래도 null이면(진짜 극초반) 한번만 더 늦춰서 재시도
+            if (approveBtnForGuide == null) {
+                binding.rvPendingList.post {
+                    val vh2 = binding.rvPendingList.findViewHolderForAdapterPosition(0)
+                    approveBtnForGuide = vh2?.itemView?.findViewById(com.example.bisit.R.id.btnApprove)
+                    Log.d(TAG, "approveBtnForGuide(retry)=$approveBtnForGuide")
+                }
+            } else {
+                Log.d(TAG, "approveBtnForGuide=$approveBtnForGuide")
             }
         }
     }

--- a/app/src/main/java/com/example/bisit/ui/todayReserv/TodayReservFragment.kt
+++ b/app/src/main/java/com/example/bisit/ui/todayReserv/TodayReservFragment.kt
@@ -1,17 +1,27 @@
 package com.example.bisit.ui.todayReserv
 
 import android.graphics.Color
+import android.graphics.Rect
+import android.graphics.RectF
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.doOnLayout
 import androidx.fragment.app.Fragment
+import com.example.bisit.MainActivity
+import com.example.bisit.R
 import com.example.bisit.databinding.FragmentTodayReservBinding
+import com.example.bisit.ui.shop.HighlightOverlayView
 import com.example.bisit.ui.todayReserv.dialog.SortOptionDialog
 
 interface SortableFragment {
-    fun sort(sortBy: String)   // "recent" | "oldest"
+    fun sort(sortBy: String)
 }
 
 class TodayReservFragment : Fragment() {
@@ -20,7 +30,6 @@ class TodayReservFragment : Fragment() {
     private val binding get() = _binding!!
 
     private var isPendingTab = false
-
     private var currentSortBy: String = "recent"
 
     override fun onCreateView(
@@ -34,13 +43,148 @@ class TodayReservFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         initTabs()
         initSortOption()
-
-        // 초기 화면: Pending 탭
         switchTab(true)
     }
+
+    override fun onResume() {
+        super.onResume()
+        refreshOnboarding()
+    }
+
+    fun refreshOnboarding() {
+        val activity = requireActivity() as MainActivity
+
+        if (!activity.isOnboardingActive()) {
+            clearGuide()
+            return
+        }
+
+        binding.root.post {
+            when (activity.currentGuideStep) {
+
+                MainActivity.GuideStep.TODAY_APPROVE -> {
+                    val child = childFragmentManager.findFragmentById(binding.fragmentContainer.id)
+                    val approveBtn =
+                        (child as? TodayApproveTargetProvider)?.getApproveButtonForGuide()
+
+                    showTodayApproveTextAndTail(
+                        big = "예약을 승인하면 이곳을 클릭하세요",
+                        approveTarget = approveBtn
+                    )
+
+                    val rects = mutableListOf<RectF>()
+                    rects += rectFOfView(binding.tabContainer)
+
+                    if (approveBtn != null) {
+                        rects += rectFOfView(approveBtn)
+                    }
+
+                    activity.showGlobalOverlayMultiple(
+                        rects = rects,
+                        shape = HighlightOverlayView.HighlightShape.ROUNDED_RECT,
+                        radiusDp = 16f
+                    )
+                }
+
+                else -> Unit
+            }
+        }
+    }
+
+    private fun showTodayApproveTextAndTail(
+        big: String,
+        approveTarget: View?
+    ) {
+        val guideLayer = getGuideLayer()
+        guideLayer.removeAllViews()
+        guideLayer.visibility = View.VISIBLE
+
+        val bigText = TextView(requireContext()).apply {
+            text = big
+            setTextColor(Color.WHITE)
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 18f)
+            setTypeface(null, android.graphics.Typeface.BOLD)
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        }
+
+        val tail = ImageView(requireContext()).apply {
+            setImageResource(R.drawable.ic_pig_tail2)
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        }
+
+        guideLayer.addView(bigText)
+        guideLayer.addView(tail)
+
+        binding.tabContainer.doOnLayout {
+            val tabRect = Rect()
+            binding.tabContainer.getGlobalVisibleRect(tabRect)
+
+            val layerLoc = IntArray(2)
+            guideLayer.getLocationOnScreen(layerLoc)
+
+            val tabBottomLocal = tabRect.bottom - layerLoc[1]
+            val left = dp(18f)
+            val textTop = tabBottomLocal + dp(20f)
+
+            bigText.x = left
+            bigText.y = textTop
+
+            tail.post {
+                val tabLeftLocal = tabRect.left - layerLoc[0]
+                val tabTopLocal = tabRect.top - layerLoc[1]
+                val tabRightLocal = tabRect.right - layerLoc[0]
+                val tabBottomLocal = tabRect.bottom - layerLoc[1]
+
+                tail.measure(
+                    View.MeasureSpec.makeMeasureSpec(guideLayer.width, View.MeasureSpec.AT_MOST),
+                    View.MeasureSpec.makeMeasureSpec(guideLayer.height, View.MeasureSpec.AT_MOST)
+                )
+                val tailW = tail.measuredWidth.toFloat()
+                val tailH = tail.measuredHeight.toFloat()
+
+                val rightMargin = dp(18f)
+                val tailX = tabRightLocal - tailW - rightMargin
+
+                val tailY = tabBottomLocal - dp(2f)
+
+                tail.x = tailX
+                tail.y = tailY
+
+                tail.bringToFront()
+                bigText.bringToFront()
+            }
+        }
+    }
+
+    private fun rectFOfView(v: View): RectF {
+        val r = Rect()
+        v.getGlobalVisibleRect(r)
+        return RectF(r)
+    }
+
+    private fun getGuideLayer(): FrameLayout {
+        return (requireActivity() as MainActivity).getGlobalGuideLayer()
+    }
+
+    private fun clearGuide() {
+        val layer = getGuideLayer()
+        layer.removeAllViews()
+        layer.visibility = View.GONE
+        (requireActivity() as MainActivity).hideGlobalOverlay()
+    }
+
+    private fun dp(value: Float): Float =
+        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value, resources.displayMetrics)
+
+    // ===== 기존 탭/정렬 로직 =====
 
     private fun initTabs() {
         binding.tabPending.setOnClickListener { switchTab(true) }
@@ -54,10 +198,7 @@ class TodayReservFragment : Fragment() {
         val fragment: Fragment =
             if (isPending) PendingReservFragment() else ApprovedReservFragment()
 
-        // 현재 정렬값을 그대로 전달
-        fragment.arguments = Bundle().apply {
-            putString("sortBy", currentSortBy)
-        }
+        fragment.arguments = Bundle().apply { putString("sortBy", currentSortBy) }
 
         childFragmentManager.beginTransaction()
             .replace(binding.fragmentContainer.id, fragment)
@@ -79,18 +220,11 @@ class TodayReservFragment : Fragment() {
 
     private fun initSortOption() {
         binding.tvSortLabel.setOnClickListener {
-
-            // 문자열 기반 SortOptionDialog 사용
             SortOptionDialog(currentSortBy) { selectedSort ->
-
-                // "recent" 또는 "oldest"
                 currentSortBy = selectedSort
-
-                // 표시되는 텍스트 변경
                 binding.tvSortLabel.text =
                     if (selectedSort == "recent") "최근 순으로" else "오래된 순으로"
 
-                // 현재 화면 Fragment 에게 정렬 요청
                 val currentFragment =
                     childFragmentManager.findFragmentById(binding.fragmentContainer.id)
 

--- a/app/src/main/java/com/example/bisit/ui/todayReserv/TodayReservGuideContracts.kt
+++ b/app/src/main/java/com/example/bisit/ui/todayReserv/TodayReservGuideContracts.kt
@@ -1,0 +1,7 @@
+package com.example.bisit.ui.todayReserv
+
+import android.view.View
+
+interface TodayApproveTargetProvider {
+    fun getApproveButtonForGuide(): View?
+}

--- a/app/src/main/res/drawable/ic_pig_tail.xml
+++ b/app/src/main/res/drawable/ic_pig_tail.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="47dp"
+    android:height="94dp"
+    android:viewportWidth="47"
+    android:viewportHeight="94">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M39.386,0.257C51.386,20.257 47.662,52.945 25.162,58.257C-10.839,66.757 -3.838,15.257 23.162,31.757C36.661,40.007 36.661,60.257 11.161,93.257"
+      android:fillColor="#00000000"
+      android:strokeColor="#FEFEFE"/>
+</vector>

--- a/app/src/main/res/drawable/ic_pig_tail2.xml
+++ b/app/src/main/res/drawable/ic_pig_tail2.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="45dp"
+    android:height="218dp"
+    android:viewportWidth="45"
+    android:viewportHeight="218">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M14.53,0.24C26.63,22.9 59.55,100.57 35.36,118.7C4.34,141.95 -15.28,91.65 17.22,97.74C53.5,104.53 42.92,179.84 17.22,217.24"
+      android:fillColor="#00000000"
+      android:strokeColor="#FEFEFE"/>
+</vector>

--- a/app/src/main/res/layout/fragment_today_reserv.xml
+++ b/app/src/main/res/layout/fragment_today_reserv.xml
@@ -24,6 +24,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center"
+        android:layout_marginHorizontal="20dp"
         android:layout_marginTop="13dp">
 
         <LinearLayout


### PR DESCRIPTION
## ✔️ 작업 내용
- 내용을 작성해주세요.
- shop & todayReserve 온보딩 연동
- 메인 액티비티 함수 추가
- 오버레이 함수 추가
- 전역 상태 추가
- 커스텀 온보딩 추가 진행 (사진 그대로 화면에 붙이면 깨지는 문제로 인해 모든 요소 커스텀(원, 라운드 사각형, 꼬리 모양, 텍스트 등))

## 📷 스크린샷
- 작업 내용에 해당하는 스크린샷을 첨부해주세요.
-

## 💬 참고 사항 <!-- 리뷰어에게 할 말을 작성해주세요. -->
- 내용을 작성해주세요.
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 온보딩 가이드 시스템 추가: 시각적 오버레이와 단계별 지침으로 새 기능 학습 지원
  * 예약 승인/거절 기능 추가
  * 서비스 등록 프로세스 개선

* **개선 사항**
  * 시각적 하이라이트 및 가이드 표시기로 인터페이스 가시성 향상
  * 예약 관리 화면 레이아웃 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->